### PR TITLE
Using `/tmp` for `go` and `golangci-lint` caches.

### DIFF
--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -5,6 +5,11 @@ set -e
 . "$(dirname "$0")"/common.sh
 
 GOLANGCI_LINT_VERSION="1.55.2"
+# This is required because the Openshift CI is running this test as a non-root
+# user but whitin the / directory as the home directory, therefore, the linter
+# won't have the permissions to create the `/.cache` directory.
+export GOCACHE=/tmp
+export GOLANGCI_LINT_CACHE=/tmp
 
 # IsGoLangCiLintInstalled is used to check whether golangci-lint executable is on the $PATH.
 function IsGolangCiLintInstalled() {
@@ -58,7 +63,7 @@ function RunGolangCiLint() {
 
 	echo "Running golangci-lint"
 
-	if golangci-lint run -v; then
+	if golangci-lint run -v --timeout 10m; then
 		return 0;
 	fi
 


### PR DESCRIPTION
The Openshift CI is running test containers with a non-root user but with the home directory configured as `/` which means that go binaries such as `golangci-lint` will try to use the `/.cache` directory with no permissions and fails.

This commit is fixing this issue.

---

/cc @empovit @wabouhamad 