### PR TITLE
Fix JUnit output directory, add dummy test

### DIFF
--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -3,7 +3,13 @@
 GOPATH="${GOPATH:-~/go}"
 PATH=$PATH:$GOPATH/bin
 TEST_DIR="./tests"
-REPORTS_DUMP_DIR="${ARTIFACT_DIR:-/tmp/reports}"
+
+# Override REPORTS_DUMP_DIR if ARTIFACT_DIR is set
+if [[ -n "${ARTIFACT_DIR}" ]]; then
+    # `export` passes the variable down to a child process,
+    # which is needed because of the `eval`
+    export REPORTS_DUMP_DIR=${ARTIFACT_DIR}
+fi
 
 # Check that TEST_FEATURES environment variable has been set
 if [[ -z "${TEST_FEATURES}" ]]; then

--- a/tests/dummy/dummy_suite_test.go
+++ b/tests/dummy/dummy_suite_test.go
@@ -1,0 +1,30 @@
+package dummy
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/reporter"
+
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/tsparams"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestDummy(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = inittools.GeneralConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Dummy", Label(), reporterConfig)
+}
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+})

--- a/tests/dummy/dummy_test.go
+++ b/tests/dummy/dummy_test.go
@@ -1,0 +1,33 @@
+package dummy
+
+import (
+	"fmt"
+
+	"github.com/kelseyhightower/envconfig"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type Config struct {
+	ReportSuccess bool `envconfig:"DUMMY_REPORT_SUCCESS" default:"true"`
+}
+
+var (
+	config *Config
+)
+
+var _ = Describe("Dummy", Ordered, Label("dummy"), func() {
+
+	Context("Dummy for testing basic CI image functionality without access to a GPU", Label("dummy"), func() {
+
+		config = new(Config)
+		err := envconfig.Process("dummy_", config)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		success := config.ReportSuccess
+
+		It("Report simple test result", Label(fmt.Sprintf("dummy-test-result:%t", success)), func() {
+			Expect(success).To(BeTrue(), "failed according to the value of DUMMY_REPORT_SUCCESS")
+		})
+	})
+})


### PR DESCRIPTION
The dummy test allows developing/troubleshooting the configuration, image, environment etc. without having a GPU or changing anything on the cluster.