### PR TITLE
Added GPU operator upgrade testcase

### DIFF
--- a/internal/nvidiagpuconfig/config.go
+++ b/internal/nvidiagpuconfig/config.go
@@ -8,12 +8,13 @@ import (
 
 // NvidiaGPUConfig contains environment information related to nvidiagpu tests.
 type NvidiaGPUConfig struct {
-	InstanceType        string `envconfig:"NVIDIAGPU_GPU_MACHINESET_INSTANCE_TYPE"`
-	CatalogSource       string `envconfig:"NVIDIAGPU_CATALOGSOURCE"`
-	SubscriptionChannel string `envconfig:"NVIDIAGPU_SUBSCRIPTION_CHANNEL"`
-	CleanupAfterTest    bool   `envconfig:"NVIDIAGPU_CLEANUP" default:"true"`
-	DeployFromBundle    bool   `envconfig:"NVIDIAGPU_DEPLOY_FROM_BUNDLE" default:"false"`
-	BundleImage         string `envconfig:"NVIDIAGPU_BUNDLE_IMAGE"`
+	InstanceType             string `envconfig:"NVIDIAGPU_GPU_MACHINESET_INSTANCE_TYPE"`
+	CatalogSource            string `envconfig:"NVIDIAGPU_CATALOGSOURCE"`
+	SubscriptionChannel      string `envconfig:"NVIDIAGPU_SUBSCRIPTION_CHANNEL"`
+	CleanupAfterTest         bool   `envconfig:"NVIDIAGPU_CLEANUP" default:"true"`
+	DeployFromBundle         bool   `envconfig:"NVIDIAGPU_DEPLOY_FROM_BUNDLE" default:"false"`
+	BundleImage              string `envconfig:"NVIDIAGPU_BUNDLE_IMAGE"`
+	OperatorUpgradeToChannel string `envconfig:"NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL"`
 }
 
 // NewNvidiaGPUConfig returns instance of NvidiaGPUConfig type.

--- a/internal/tsparams/consts.go
+++ b/internal/tsparams/consts.go
@@ -1,7 +1,7 @@
 package tsparams
 
 const (
-	// LabelSuite represents kmm label that can be used for test cases selection.
+	// LabelSuite represents gpu label that can be used for test cases selection.
 	LabelSuite = "gpu"
 	// GPUTestNamespace represents test case namespace name.
 	GPUTestNamespace = "test-gpu-burn"

--- a/tests/nvidiagpu/deploy-gpu-test.go
+++ b/tests/nvidiagpu/deploy-gpu-test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	nvidiagpuv1 "github.com/NVIDIA/gpu-operator/api/v1"
+	nvidiagpuv1alpha1 "github.com/NVIDIA/k8s-operator-libs/api/upgrade/v1alpha1"
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools"
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/nvidiagpuconfig"
 
@@ -59,11 +61,13 @@ var (
 	gpuCatalogSource                   = "undefined"
 	gpuSubscriptionChannel             = "undefined"
 	gpuDefaultSubscriptionChannel      = "undefined"
+	gpuOperatorUpgradeToChannel        = "undefined"
 	cleanupAfterTest              bool = true
 	deployFromBundle              bool = false
 	gpuOperatorBundleImage             = ""
 	gpuCurrentCSV                      = ""
 	gpuCurrentCSVVersion               = ""
+	clusterArchitecture                = "undefined"
 )
 
 const (
@@ -101,9 +105,9 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 		deployBundle deploy.Deploy
 	)
 
-	Context("DeployGpu", Label("deploy-gpu-with-dtk"), func() {
+	nvidiaGPUConfig = nvidiagpuconfig.NewNvidiaGPUConfig()
 
-		nvidiaGPUConfig = nvidiagpuconfig.NewNvidiaGPUConfig()
+	Context("DeployGpu", Label("deploy-gpu-with-dtk"), func() {
 
 		BeforeAll(func() {
 			if nvidiaGPUConfig.InstanceType == "" {
@@ -164,6 +168,16 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				glog.V(gpuparams.GpuLogLevel).Infof("env variable NVIDIAGPU_DEPLOY_FROM_BUNDLE" +
 					" is set to false or is not set, will deploy GPU Operator from catalogsource")
 				deployFromBundle = false
+			}
+
+			if nvidiaGPUConfig.OperatorUpgradeToChannel == "" {
+				glog.V(gpuparams.GpuLogLevel).Infof("env variable NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL" +
+					" is not set, will not run the Upgrade Testcase")
+				gpuOperatorUpgradeToChannel = "undefined"
+			} else {
+				gpuOperatorUpgradeToChannel = nvidiaGPUConfig.OperatorUpgradeToChannel
+				glog.V(gpuparams.GpuLogLevel).Infof("GPU Operator Upgrade to channel now set to env variable "+
+					"NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL value '%s'", gpuOperatorUpgradeToChannel)
 			}
 
 			By("Report OpenShift version")
@@ -370,8 +384,10 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				"gpuWorkerNodeSelector: %v", gpuWorkerNodeSelector)
 			clusterArch, err := get.GetClusterArchitecture(inittools.APIClient, gpuWorkerNodeSelector)
 			Expect(err).ToNot(HaveOccurred(), "error getting cluster architecture:  %v ", err)
+
+			clusterArchitecture = clusterArch
 			glog.V(gpuparams.GpuLogLevel).Infof("cluster architecture for GPU enabled worker node is: %s",
-				clusterArch)
+				clusterArchitecture)
 
 			By("Check if GPU Operator Deployment is from Bundle")
 			if deployFromBundle {
@@ -729,10 +745,10 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By("Deploy gpu-burn pod in test-gpu-burn namespace")
 			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod image name is: '%s', in namespace '%s'",
-				gpuBurnImageName[clusterArch])
+				gpuBurnImageName[clusterArchitecture])
 
 			gpuBurnPod, err := gpuburn.CreateGPUBurnPod(inittools.APIClient, gpuBurnPodName, gpuBurnNamespace,
-				gpuBurnImageName[(clusterArch)], 5*time.Minute)
+				gpuBurnImageName[(clusterArchitecture)], 5*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Error creating gpu burn pod: %v", err)
 
 			glog.V(gpuparams.GpuLogLevel).Infof("Creating gpu-burn pod '%s' in namespace '%s'",
@@ -757,8 +773,9 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 			Expect(err).ToNot(HaveOccurred(), "error pulling gpu-burn pod from "+
 				"namespace '%s' :  %v ", gpuBurnNamespace, err)
 
+			By("Cleanup gpu-burn pod only if cleanupAfterTest is true and gpuOperatorUpgradeToChannel is undefined")
 			defer func() {
-				if cleanupAfterTest {
+				if cleanupAfterTest && gpuOperatorUpgradeToChannel == "undefined" {
 					_, err := gpuPodPulled.Delete()
 					Expect(err).ToNot(HaveOccurred())
 				}
@@ -794,5 +811,239 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 			glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod execution was successful")
 
 		})
+
+		It("Upgrade NVIDIA GPU Operator", Label("operator-upgrade"), func() {
+
+			if gpuOperatorUpgradeToChannel == "undefined" {
+				glog.V(gpuparams.GpuLogLevel).Infof("Operator Upgrade To Channel not set, skipping " +
+					"Operator Upgrade Testcase")
+				Skip("Operator Upgrade To Channel not set, skipping Operator Upgrade Testcase")
+			}
+
+			By("Starting GPU Operator Upgrade testcase")
+			glog.V(gpuparams.GpuLogLevel).Infof("\"Starting GPU Operator Upgrade testcase")
+
+			glog.V(100).Infof(
+				"Pulling ClusterPolicy builder structure named '%s'", gpuClusterPolicyName)
+			pulledClusterPolicyBuilder, err := nvidiagpu.Pull(inittools.APIClient, gpuClusterPolicyName)
+
+			Expect(err).ToNot(HaveOccurred(), "error pulling ClusterPolicy builder object name '%s' "+
+				"from cluster: %v", gpuClusterPolicyName, err)
+
+			glog.V(100).Infof(
+				"Pulled ClusterPolicy builder structure named '%s'", pulledClusterPolicyBuilder.Object.Name)
+
+			By("Capturing current clusterPolicy ResourceVersion")
+			initialClusterPolicyResourceVersion := pulledClusterPolicyBuilder.Object.ResourceVersion
+			glog.V(100).Infof(
+				"Pulled ClusterPolicy resourceVersion is '%s'", initialClusterPolicyResourceVersion)
+
+			By("Updating ClusterPolicy rollingUpdate.MaxUnavailable and Driver.UpgradePolicy fields")
+			var maxUnavailable = "1"
+			glog.V(100).Infof(
+				"Setting pulled ClusterPolicy builder daemonset rollingUpdate.MaxUnavailable value to '%s'",
+				maxUnavailable)
+
+			myRollingUpdate := nvidiagpuv1.RollingUpdateSpec{
+				MaxUnavailable: maxUnavailable,
+			}
+
+			if pulledClusterPolicyBuilder.Definition.Spec.Daemonsets.RollingUpdate == nil {
+				pulledClusterPolicyBuilder.Definition.Spec.Daemonsets.RollingUpdate = &myRollingUpdate
+			}
+
+			myDriverAutoUpgradeTrue := nvidiagpuv1alpha1.DriverUpgradePolicySpec{
+				AutoUpgrade: true}
+
+			if pulledClusterPolicyBuilder.Definition.Spec.Driver.UpgradePolicy == nil {
+				pulledClusterPolicyBuilder.Definition.Spec.Driver.UpgradePolicy = &myDriverAutoUpgradeTrue
+			}
+
+			pulledClusterPolicyBuilder.Definition.Spec.Daemonsets.RollingUpdate.MaxUnavailable = maxUnavailable
+			updatedPulledClusterPolicyBuilder, err := pulledClusterPolicyBuilder.Update(true)
+
+			Expect(err).ToNot(HaveOccurred(), "error updating pulled ClusterPolicy builder"+
+				" daemonset rollingUpdate.MaxUnavailable and Driver.UpgradePolicy fields:  %v", err)
+
+			By("Capturing updated clusterPolicy ResourceVersion")
+			updatedClusterPolicyResourceVersion := updatedPulledClusterPolicyBuilder.Object.ResourceVersion
+			glog.V(100).Infof(
+				"Pulled ClusterPolicy resourceVersion is '%s'", updatedClusterPolicyResourceVersion)
+
+			glog.V(100).Infof(
+				"After updating pulled ClusterPolicy builder, value of daemonset rollingUpdate.MaxUnavailable "+
+					"value is now '%v'",
+				updatedPulledClusterPolicyBuilder.Definition.Spec.Daemonsets.RollingUpdate.MaxUnavailable)
+
+			glog.V(100).Infof(
+				"Pulling SubscriptionBuilder structure with the following params: %s, %s", gpuSubscriptionName,
+				gpuSubscriptionNamespace)
+
+			pulledSubBuilder, err := olm.PullSubscription(inittools.APIClient, gpuSubscriptionName,
+				gpuSubscriptionNamespace)
+
+			Expect(err).ToNot(HaveOccurred(), "Error pulling subscription '%s' in "+
+				"namespace '%s': %v", gpuSubscriptionName, gpuSubscriptionNamespace, err)
+
+			glog.V(100).Infof(
+				"Successfully Initialized pulledNodeBuilder with name: %s", pulledSubBuilder.Definition.Name)
+
+			glog.V(100).Infof("Current Subscription Channel : %s", pulledSubBuilder.Definition.Spec.Channel)
+
+			pulledSubBuilder.Definition.Spec.Channel = gpuOperatorUpgradeToChannel
+			glog.V(100).Infof("Updating Subscription Channel to upgrade to : %s",
+				pulledSubBuilder.Definition.Spec.Channel)
+
+			glog.V(100).Infof(
+				"Before Subcsription Channel upgrade the StartingCSV is now '%s'",
+				pulledSubBuilder.Object.Spec.StartingCSV)
+
+			By("Update the Subscription builder object with new channel value")
+			updatedPulledSubBuilder, err := pulledSubBuilder.Update()
+
+			Expect(err).ToNot(HaveOccurred(), "Error updating pulled subscription '%s' in "+
+				"namespace '%s': %v", gpuSubscriptionName, gpuSubscriptionNamespace, err)
+
+			glog.V(100).Infof("Successfully updated Subscription Channel to upgrade to '%s'",
+				updatedPulledSubBuilder.Definition.Spec.Channel)
+
+			glog.V(100).Infof("Sleeping 2 minute to allow new CSV to be deployed")
+			time.Sleep(2 * time.Minute)
+
+			glog.V(100).Infof("After Subscription Channel upgrade, the StartingCSV is now '%s'",
+				updatedPulledSubBuilder.Object.Spec.StartingCSV)
+
+			By("Wait for daemonsets to be redeployed up to 15 minutes and for ClusterPolicy to be ready again")
+			glog.V(gpuparams.GpuLogLevel).Infof("Waiting up to 15 mins for ClusterPolicy to be ready again " +
+				"after upgrade")
+			err = wait.ClusterPolicyReady(inittools.APIClient, gpuClusterPolicyName, 60*time.Second, 15*time.Minute)
+
+			glog.V(gpuparams.GpuLogLevel).Infof("error waiting for ClusterPolicy to be Ready:  %v ", err)
+			Expect(err).ToNot(HaveOccurred(), "error waiting for ClusterPolicy to be Ready:  %v ",
+				err)
+
+			By("Pull the post-upgrade Ready ClusterPolicy from cluster, with updated fields")
+			pulledUpdatedReadyClusterPolicy, err := nvidiagpu.Pull(inittools.APIClient, gpuClusterPolicyName)
+			Expect(err).ToNot(HaveOccurred(), "error pulling ClusterPolicy %s from cluster: "+
+				" %v ", gpuClusterPolicyName, err)
+
+			By("Capturing Post-Upgrade clusterPolicy ResourceVersion")
+			updatedReadyClusterPolicyResourceVersion := pulledUpdatedReadyClusterPolicy.Object.ResourceVersion
+			glog.V(100).Infof("Pulled Post-Upgrade Ready ClusterPolicy resourceVersion is '%s'",
+				updatedReadyClusterPolicyResourceVersion)
+
+			By("Comparing previous and updated and ready clusterPolicy ResourceVersions")
+			glog.V(100).Infof(
+				"Previous ClusterPolicy resourceVersion is '%s', updated and Ready clusterPolicy resource "+
+					"version is '%s'", updatedClusterPolicyResourceVersion, updatedReadyClusterPolicyResourceVersion)
+			Expect(updatedClusterPolicyResourceVersion).To(Not(Equal(updatedReadyClusterPolicyResourceVersion)),
+				"ClusterPolicy resourceVersion strings are equal")
+
+			cpReadyAgainJSON, err := json.MarshalIndent(pulledUpdatedReadyClusterPolicy, "", " ")
+
+			Expect(err).ToNot(HaveOccurred(), "Error marshalling the ready ClusterPolicy into json: "+
+				" %v", err)
+
+			glog.V(gpuparams.GpuLogLevel).Infof("The ready ClusterPolicy after upgrade has name:  %v",
+				pulledUpdatedReadyClusterPolicy.Definition.Name)
+			glog.V(gpuparams.GpuLogLevel).Infof("The ready ClusterPolicy just marshalled "+
+				"in json: %v", string(cpReadyAgainJSON))
+
+			By("Pull the previously deployed gpu-burn pod object from the cluster")
+			currentGpuBurnPodPulled, err := pod.Pull(inittools.APIClient, gpuBurnPodName, gpuBurnNamespace)
+			Expect(err).ToNot(HaveOccurred(), "error pulling previously deployed and completed "+
+				"gpu-burn pod from namespace '%s' :  %v ", gpuBurnNamespace, err)
+
+			By("Get the gpu-burn pod with label \"app=gpu-burn-app\"")
+			currentGpuBurnPodName, err := get.GetFirstPodNameWithLabel(inittools.APIClient, gpuBurnNamespace,
+				gpuBurnPodLabel)
+			Expect(err).ToNot(HaveOccurred(), "error getting previously deployed gpu-burn pod "+
+				"with label 'app=gpu-burn-app' from namespace '%s' :  %v ", gpuBurnNamespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("gpuPodName is %s ", currentGpuBurnPodName)
+
+			By("Delete the previously deployed gpu-burn-pod")
+			glog.V(gpuparams.GpuLogLevel).Infof("Deleting previously deployed and completed gpu-burn pod")
+
+			_, err = currentGpuBurnPodPulled.Delete()
+			Expect(err).ToNot(HaveOccurred(), "Error deleting gpu-burn pod")
+
+			By("Re-deploy gpu-burn pod in test-gpu-burn namespace")
+			glog.V(gpuparams.GpuLogLevel).Infof("Re-deployed gpu-burn pod image name is: '%s', in "+
+				"namespace '%s'", gpuBurnImageName[clusterArchitecture], gpuBurnNamespace)
+
+			By("Get Cluster Architecture from first GPU enabled worker node")
+			glog.V(gpuparams.GpuLogLevel).Infof("Getting cluster architecture from nodes with "+
+				"gpuWorkerNodeSelector: %v", gpuWorkerNodeSelector)
+			clusterArch, err := get.GetClusterArchitecture(inittools.APIClient, gpuWorkerNodeSelector)
+			Expect(err).ToNot(HaveOccurred(), "error getting cluster architecture:  %v ", err)
+
+			glog.V(gpuparams.GpuLogLevel).Infof("cluster architecture for GPU enabled worker node is: %s",
+				clusterArch)
+
+			gpuBurnPod2, err := gpuburn.CreateGPUBurnPod(inittools.APIClient, gpuBurnPodName, gpuBurnNamespace,
+				gpuBurnImageName[(clusterArch)], 5*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "Error re-building gpu burn pod object after "+
+				"upgrade: %v", err)
+
+			glog.V(gpuparams.GpuLogLevel).Infof("Re-deploying gpu-burn pod '%s' in namespace '%s'",
+				gpuBurnPodName, gpuBurnNamespace)
+
+			_, err = inittools.APIClient.Pods(gpuBurnNamespace).Create(context.TODO(), gpuBurnPod2,
+				metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Error re-deploying gpu-burn '%s' after operator"+
+				" upgrade in namespace '%s': %v", gpuBurnPodName, gpuBurnNamespace, err)
+
+			glog.V(gpuparams.GpuLogLevel).Infof("The re-deployed post upgrade gpuBurnPod has name: %s has "+
+				"status: %v ", gpuBurnPod2.Name, gpuBurnPod2.Status)
+
+			By("Get the re-deployed gpu-burn pod with label \"app=gpu-burn-app\"")
+			gpuBurnPod2Name, err := get.GetFirstPodNameWithLabel(inittools.APIClient, gpuBurnNamespace, gpuBurnPodLabel)
+			Expect(err).ToNot(HaveOccurred(), "error getting re-deployed gpu-burn pod with label "+
+				"'app=gpu-burn-app' from namespace '%s' :  %v ", gpuBurnNamespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("gpuPodName is %s ", gpuBurnPod2Name)
+
+			By("Pull the re-created gpu-burn pod object from the cluster")
+			gpuBurnPod2Pulled, err := pod.Pull(inittools.APIClient, gpuBurnPod2.Name, gpuBurnNamespace)
+			Expect(err).ToNot(HaveOccurred(), "error pulling re-deployed gpu-burn pod from "+
+				"namespace '%s' :  %v ", gpuBurnNamespace, err)
+
+			defer func() {
+				if cleanupAfterTest {
+					_, err := gpuBurnPod2Pulled.Delete()
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}()
+
+			By("Wait for up to 3 minutes for re-deployed gpu-burn pod to be in Running phase")
+			err = gpuBurnPod2Pulled.WaitUntilInStatus(corev1.PodRunning, 3*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "timeout waiting for re-deployed gpu-burn pod in "+
+				"namespace '%s' to go to Running phase:  %v ", gpuBurnNamespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running phase")
+
+			By("Wait for re-deployed gpu-burn pod to run to completion and be in Succeeded phase/Completed status")
+			err = gpuBurnPod2Pulled.WaitUntilInStatus(corev1.PodSucceeded, 8*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod '%s' in "+
+				"namespace '%s'to go Succeeded phase/Completed status:  %v ", gpuBurnPodName, gpuBurnNamespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Succeeded Phase/Completed status")
+
+			By("Get the gpu-burn pod logs")
+			glog.V(gpuparams.GpuLogLevel).Infof("Get the re-created gpu-burn pod logs")
+
+			gpuBurnPod2Logs, err := gpuBurnPod2Pulled.GetLog(500*time.Second, "gpu-burn-ctr")
+
+			Expect(err).ToNot(HaveOccurred(), "error getting gpu-burn pod '%s' logs "+
+				"from gpu burn namespace '%s' :  %v ", gpuBurnNamespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod '%s' logs:\n%s",
+				gpuBurnPod2Pulled.Definition.Name, gpuBurnPod2Logs)
+
+			By("Parse the re-created gpu-burn pod logs and check for successful execution")
+			match1a := strings.Contains(gpuBurnPod2Logs, "GPU 0: OK")
+			match2a := strings.Contains(gpuBurnPod2Logs, "100.0%  proc'd:")
+
+			Expect(match1a && match2a).ToNot(BeFalse(), "Re-deployed gpu-burn pod execution was FAILED")
+			glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod execution was successful")
+
+		})
+
 	})
 })


### PR DESCRIPTION
The GPU operator upgrade testcase can now run after running the end-to-end testcase and running a gpu-burn workload.   

With the specified labels and channel to upgrade to (see updated (README file), the upgrade testcase will run after the end-to-end testcase.  It will redeploys the GPU stack with the newer CSV and run a new gpu-burn workload.

If the required labels are not specified, only the -end-end testcase will run.