### PR TITLE
Delete OLM pods if NFD deployment fails on 4.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ replace (
 
 require (
 	github.com/NVIDIA/gpu-operator v1.8.3-0.20240429200431-0fe1e8db32b0
+	github.com/NVIDIA/k8s-operator-libs v0.0.0-20240214071211-ea58a3ada15c
 	github.com/golang/glog v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.17.1
@@ -65,7 +66,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/NVIDIA/k8s-kata-manager v0.0.0-20230620232711-08b57feb9b5a // indirect
-	github.com/NVIDIA/k8s-operator-libs v0.0.0-20240214071211-ea58a3ada15c // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect


### PR DESCRIPTION
As part of the temporary workaround, delete OLM pods to trigger cache rebuild. We don't know why the issue is happening, and cannot reproduce it, so this is just another attempt to work around it.