### PR TITLE
Deleting olm pods regardless ocp version

### DIFF
--- a/tests/nvidiagpu/deploy-gpu-test.go
+++ b/tests/nvidiagpu/deploy-gpu-test.go
@@ -335,7 +335,7 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 				nfdDeployed := createNFDDeployment()
 
-				if !nfdDeployed && strings.HasPrefix(ocpVersion, "4.15.") {
+				if !nfdDeployed {
 					By(fmt.Sprintf("Applying workaround for NFD failing to deploy on OCP %s", ocpVersion))
 					err = deploy.DeleteNFDSubscription(inittools.APIClient)
 					Expect(err).ToNot(HaveOccurred(), "error deleting NFD subscription: %v", err)


### PR DESCRIPTION
We saw in #39 the problem in nfd that was fixed, this problem happened in other version.
With that commit we aim to delete olm pods no matter what ocp version is installed.