### PR TITLE
reporting ClusterPolicy

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,8 +100,19 @@ func (cfg *GeneralConfig) GetDumpFailedTestReportLocation(file string) string {
 
 		return filepath.Join(cfg.ReportsDirAbsPath, fmt.Sprintf("failed_%s", dumpFileName))
 	}
-
 	return ""
+}
+
+// GetDumpTestReportLocation returns destination file for failed tests logs.
+func (cfg *GeneralConfig) GetDumpTestReportLocation(file string) string {
+	if _, err := os.Stat(cfg.ReportsDirAbsPath); os.IsNotExist(err) {
+		err := os.MkdirAll(cfg.ReportsDirAbsPath, 0744)
+		if err != nil {
+			log.Fatalf("panic: Failed to create report dir due to %s", err)
+		}
+	}
+	dumpFileName := strings.TrimSuffix(filepath.Base(file), filepath.Ext(filepath.Base(file)))
+	return filepath.Join(cfg.ReportsDirAbsPath, dumpFileName)
 }
 
 func readFile(cfg *GeneralConfig, cfgFile string) error {

--- a/tests/nvidiagpu/gpu_suite_test.go
+++ b/tests/nvidiagpu/gpu_suite_test.go
@@ -25,6 +25,9 @@ func TestGPUDeploy(t *testing.T) {
 }
 
 var _ = JustAfterEach(func() {
+	csr := CurrentSpecReport()
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		csr, currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+	reporter.Report(
+		csr, currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
 })


### PR DESCRIPTION
Problem: we want to collect ClusterPolicy CRs for logs.
Solution: lets report it back the same way as we already do when the test fails.

#### Note

I did not change the old way of reporting it if it failed, in order to separate the cases (even though right now we report almost the same thing).
If you think we should change that please let me know.

---

/cc @empovit @wabouhamad 