### PR TITLE
Using nvidia's must-gather.sh

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,11 @@
+FROM quay.io/openshift/origin-cli:4.20 as oc-cli
 FROM registry.access.redhat.com/ubi9/go-toolset:1.21
 
 LABEL org.opencontainers.image.authors="Red Hat Ecosystem Engineering"
 
 USER root
+# Copying oc binary
+COPY --from=oc-cli /usr/bin/oc /usr/bin/oc
 
 # Install dependencies: `operator-sdk`
 ARG OPERATOR_SDK_VERSION=v1.6.2
@@ -32,5 +35,8 @@ RUN make install-ginkgo
 RUN mkdir -p "${ARTIFACT_DIR}" && chmod 777 "${ARTIFACT_DIR}"
 RUN mkdir -p "${GOCACHE}" && chmod 777 "${GOCACHE}"
 RUN chmod 777 /root/nvidia-ci -R
+ARG GPU_OPERATOR_VERSION=v23.9.1
+RUN curl -SsL -o gpu-operator-must-gather.sh -L https://raw.githubusercontent.com/NVIDIA/gpu-operator/${GPU_OPERATOR_VERSION}/hack/must-gather.sh && \
+    chmod +x gpu-operator-must-gather.sh
 
 ENTRYPOINT ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,17 @@ TEST ?= ...
 unit-test:
 	go test github.com/rh-ecosystem-edge/nvidia-ci/$(TEST)
 
-run-tests:
+get-gpu-operator-must-gather:
+	test -s gpu-operator-must-gather.sh || (\
+    		SCRIPT_URL="https://raw.githubusercontent.com/NVIDIA/gpu-operator/v23.9.1/hack/must-gather.sh" && \
+    		if ! curl -SsL -o gpu-operator-must-gather.sh -L $$SCRIPT_URL; then \
+    			echo "Failed to download must-gather script" >&2; \
+    			exit 1; \
+    		fi && \
+    		chmod +x gpu-operator-must-gather.sh \
+    	)
+
+run-tests: get-gpu-operator-must-gather
 	@echo "Executing nvidiagpu test-runner script"
 	scripts/test-runner.sh
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,17 +90,15 @@ func (cfg *GeneralConfig) WriteReport(fileName string, content []byte) error {
 func (cfg *GeneralConfig) GetDumpFailedTestReportLocation(file string) string {
 	if cfg.DumpFailedTests {
 		if _, err := os.Stat(cfg.ReportsDirAbsPath); os.IsNotExist(err) {
+			log.Printf("Path to report dir %s does not exist, trying to create now", cfg.ReportsDirAbsPath)
 			err := os.MkdirAll(cfg.ReportsDirAbsPath, 0744)
 			if err != nil {
 				log.Fatalf("panic: Failed to create report dir due to %s", err)
 			}
 		}
-
 		dumpFileName := strings.TrimSuffix(filepath.Base(file), filepath.Ext(filepath.Base(file)))
-
 		return filepath.Join(cfg.ReportsDirAbsPath, fmt.Sprintf("failed_%s", dumpFileName))
 	}
-
 	return ""
 }
 

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -26,18 +26,22 @@ func ClusterPolicyReady(apiClient *clients.Settings, clusterPolicyName string, p
 				return false, err
 			}
 
-			if clusterPolicy.Object.Status.State == "ready" {
+			if clusterPolicy.Object != nil && clusterPolicy.Object.Status.State == "ready" {
 				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy %s in now in %s state",
 					clusterPolicy.Object.Name, clusterPolicy.Object.Status.State)
 
 				// this exists out of the wait.PollImmediate()
 				return true, nil
 			}
+			if clusterPolicy.Object == nil {
+				glog.V(gpuparams.GpuLogLevel).Info("ClusterPolicy object is nil")
+				return false, nil
+			}
 
 			glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy %s in now in %s state",
 				clusterPolicy.Object.Name, clusterPolicy.Object.Status.State)
 
-			return false, err
+			return false, nil
 		})
 }
 

--- a/pkg/olm/catalogsource.go
+++ b/pkg/olm/catalogsource.go
@@ -229,7 +229,7 @@ func (builder *CatalogSourceBuilder) IsReady(timeout time.Duration) bool {
 				return false, err
 			}
 
-			if builder.Object.Status.GRPCConnectionState.LastObservedState == "READY" {
+			if builder.Object != nil && builder.Object.Status.GRPCConnectionState != nil && builder.Object.Status.GRPCConnectionState.LastObservedState == "READY" {
 				return true, nil
 			}
 

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -46,7 +46,7 @@ fi
 
 
 # Build ginkgo command
-cmd="ginkgo -timeout=24h --keep-going --require-suite -r"
+cmd="PATH_TO_MUST_GATHER_SCRIPT=$(pwd)/gpu-operator-must-gather.sh ginkgo -timeout=24h --keep-going --require-suite -r"
 
 if [[ "${TEST_VERBOSE}" == "true" ]]; then
     cmd+=" -vv"
@@ -60,6 +60,7 @@ if [[ ! -z "${TEST_LABELS}" ]]; then
     cmd+=" --label-filter=\"${TEST_LABELS}\""
 fi
 cmd+=" "$feature_dirs" $@"   # + user args --xxx=yyy...
+
 
 # Execute ginkgo command
 echo $cmd

--- a/tests/dummy/dummy_suite_test.go
+++ b/tests/dummy/dummy_suite_test.go
@@ -1,11 +1,10 @@
 package dummy
 
 import (
-	"runtime"
-	"testing"
-
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/reporter"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
+	"runtime"
+	"testing"
 
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools"
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/tsparams"

--- a/tests/nvidiagpu/gpu_suite_test.go
+++ b/tests/nvidiagpu/gpu_suite_test.go
@@ -1,8 +1,15 @@
 package nvidiagpu
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+	"os"
+	"os/exec"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/reporter"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
@@ -27,4 +34,29 @@ func TestGPUDeploy(t *testing.T) {
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
 		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+
+	dumpDir := inittools.GeneralConfig.GetDumpFailedTestReportLocation(currentFile)
+	if dumpDir != "" {
+		artifactDir := fmt.Sprintf("ARTIFACT_DIR=%s/gpu-must-gather", dumpDir)
+		mustGatherScriptPath := os.Getenv("PATH_TO_MUST_GATHER_SCRIPT")
+		if mustGatherScriptPath == "" {
+			glog.Error("PATH_TO_MUST_GATHER_SCRIPT environment variable is not set")
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, mustGatherScriptPath)
+		cmd.Env = append(os.Environ(), artifactDir)
+		output, err := cmd.CombinedOutput()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			glog.Errorf("gpu-operator-must-gather.sh script timed out: %v", ctx.Err())
+			return
+		}
+		if err != nil {
+			glog.Errorf("Error running gpu-operator-must-gather.sh script: %v\nOutput: %s", err, output)
+		} else {
+			glog.V(100).Infof("Must-gather script output: %s", output)
+		}
+	}
 })


### PR DESCRIPTION
We want to collect artifacts the same way as Nvidia does in their operator.
Now we download their must-gather script and uses it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for downloading and executing a GPU operator must-gather script during testing
  - Enhanced test reporting with artifact collection for failed tests

- **Bug Fixes**
  - Improved error handling in various components to prevent potential nil pointer dereferences
  - Added null checks in readiness verification for catalog sources and cluster policies

- **Chores**
  - Updated Containerfile to include OpenShift CLI binary
  - Reorganized test suite import statements
  - Added logging for better visibility during test execution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->