### PR TITLE
increased waiting time for ClusterPolicy, from 12minutes to 20minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is an automation/CI framework to test NVIDIA operators, the GPU 
 This project is based on golang + [ginkgo](https://onsi.github.io/ginkgo) framework.
 
 ### Project requirements
-Golang and ginkgo versions based on versions specified in `go.mmod` file.
+Golang and ginkgo versions based on versions specified in `go.mod` file.
 
 The framework in this repository is designed to test NVIDIA's operators on a pre-installed OpenShift Container Platform
 (OCP) cluster which meets the following requirements:

--- a/tests/nvidiagpu/deploy-gpu-test.go
+++ b/tests/nvidiagpu/deploy-gpu-test.go
@@ -826,7 +826,7 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By("Wait up to 12 minutes for ClusterPolicy to be ready")
 			glog.V(gpuparams.GpuLogLevel).Infof("Waiting for ClusterPolicy to be ready")
-			err = wait.ClusterPolicyReady(inittools.APIClient, gpuClusterPolicyName, 60*time.Second, 12*time.Minute)
+			err = wait.ClusterPolicyReady(inittools.APIClient, gpuClusterPolicyName, 60*time.Second, 20*time.Minute)
 
 			glog.V(gpuparams.GpuLogLevel).Infof("error waiting for ClusterPolicy to be Ready:  %v ", err)
 			Expect(err).ToNot(HaveOccurred(), "error waiting for ClusterPolicy to be Ready:  %v ",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README.md to correct a typographical error in the Go module file reference.

- **Tests**
	- Extended timeout for GPU deployment test from 12 to 20 minutes to allow more time for ClusterPolicy readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->