### PR TITLE
Update top-of-tree GPU Operator OLM bundle image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ NVIDIA GPU Operator-specific parameters for the script are controlled by the fol
   - Example instance type: "g4dn.xlarge" in AWS, or "a2-highgpu-1g" in GCP, or "Standard_NC4as_T4_v3" in Azure - _required when need to scale cluster to add GPU node_
 - `NVIDIAGPU_CATALOGSOURCE`: custom catalogsource to be used.  If not specified, the default "certified-operators" catalog is used - _optional_
 - `NVIDIAGPU_SUBSCRIPTION_CHANNEL`: specific subscription channel to be used.  If not specified, the latest channel is used - _optional_
-- `NVIDIAGPU_BUNDLE_IMAGE`: GPU Operator bundle image to deploy with operator-sdk if NVIDIAGPU_DEPLOY_FROM_BUNDLE variable is set to true.  Default value for bundle image if not set: registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-bundle:main-latest - _optional when deploying from bundlle_
+- `NVIDIAGPU_BUNDLE_IMAGE`: GPU Operator bundle image to deploy with operator-sdk if NVIDIAGPU_DEPLOY_FROM_BUNDLE variable is set to true.  Default value for bundle image if not set: ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:main-latest - _optional when deploying from bundlle_
 - `NVIDIAGPU_DEPLOY_FROM_BUNDLE`: boolean flag to deploy GPU operator from bundle image with operator-sdk - Default value is false - _required when deploying from bundle_
 - `NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL`: specific subscription channel to upgrade to from previous version.  _required when running operator-upgrade testcase_
 - `NVIDIAGPU_CLEANUP`: boolean flag to cleanup up resources created by testcase after testcase execution - Default value is true - _required only when cleanup is not needed_

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -17,7 +17,7 @@ import (
 //go:generate mockgen -package=deploy -destination mock_appsv1.go k8s.io/client-go/kubernetes/typed/apps/v1 AppsV1Interface,DeploymentInterface
 
 type BundleConfig struct {
-	BundleImage string `required:"true" envconfig:"NVIDIAGPU_BUNDLE_IMAGE" default:"registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-bundle:main-latest"`
+	BundleImage string `required:"true" envconfig:"NVIDIAGPU_BUNDLE_IMAGE" default:"ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:main-latest"`
 }
 
 //go:generate mockgen -source=deploy.go -package=deploy -destination=mock_deploy.go

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GetBundleConfig", func() {
 
 		bundleConfig, err := deploy.GetBundleConfig(logLevel)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(bundleConfig.BundleImage).To(Equal("registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-bundle:main-latest"))
+		Expect(bundleConfig.BundleImage).To(Equal("ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:main-latest"))
 	})
 
 	It("should override the default value", func() {

--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,9 @@
         "gpu_operator_staging_digest:\\s*\"(?<currentDigest>sha256:[a-f0-9]+)\""
       ],
       "datasourceTemplate": "docker",
-      "depNameTemplate": "registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-bundle",
+      "depNameTemplate": "ghcr.io/nvidia/gpu-operator/gpu-operator-bundle",
       "currentValueTemplate": "main-latest",
-      "registryUrlTemplate": "https://registry.gitlab.com"
+      "registryUrlTemplate": "https://ghcr.io"
     },
     {
       "description": "Manage NVIDIA GPU Operator Docker image versions for minors 24.6, 24.9, and 24.12",

--- a/tests/nvidiagpu/deploy-gpu-test.go
+++ b/tests/nvidiagpu/deploy-gpu-test.go
@@ -105,7 +105,7 @@ const (
 	gpuBurnPodName                      = "gpu-burn-pod"
 	gpuBurnPodLabel                     = "app=gpu-burn-app"
 	gpuBurnConfigmapName                = "gpu-burn-entrypoint"
-	gpuOperatorDefaultMasterBundleImage = "registry.gitlab.com/nvidia/kubernetes/gpu-operator/staging/gpu-operator-bundle:main-latest"
+	gpuOperatorDefaultMasterBundleImage = "ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:main-latest"
 
 	gpuCustomCatalogSourcePublisherName    = "Red Hat"
 	nfdCustomNFDCatalogSourcePublisherName = "Red Hat"


### PR DESCRIPTION
Updating GPU Operator OLM master bundle image path to new link:

ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:main-latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the default GPU operator bundle image reference in the README to reflect the new source from GitHub Container Registry instead of GitLab.

- **Chores**
  - Standardized the default GPU operator bundle image reference across configurations for consistent deployment outcomes when using the bundle option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->