### PR TITLE
Fixing pr comment for ocp stable version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,7 @@
       "description": "Set PR notes for stable OpenShift version updates",
       "matchPackageNames": ["openshift-release-dev/ocp-release"],
       "matchDepPatterns": ["^ocp-(?<minor>12|13|14|15|16|17|18|19|20|21)$"],
-      "prBodyNotes": ["/test 4.{{replace 'ocp-rc-' '' depName}}-stable-nvidia-gpu-operator-e2e-master 4.{{replace 'ocp-rc-' '' depName}}-stable-nvidia-gpu-operator-e2e-24-9-x 4.{{replace 'ocp-rc-' '' depName}}-stable-nvidia-gpu-operator-e2e-24-6-x"]
+      "prBodyNotes": ["/test 4.{{replace 'ocp-' '' depName}}-stable-nvidia-gpu-operator-e2e-master 4.{{replace 'ocp-' '' depName}}-stable-nvidia-gpu-operator-e2e-24-9-x 4.{{replace 'ocp-' '' depName}}-stable-nvidia-gpu-operator-e2e-24-6-x"]
     },
     {
       "description": "Set PR notes for OpenShift RC updates",


### PR DESCRIPTION
Right now the the bot creates prs with wrong job names, for example `/test 4.ocp-17-stable-nvidia-gpu-operator-e2e-master 4.ocp-17-stable-nvidia-gpu-operator-e2e-24-9-x 4.ocp-17-stable-nvidia-gpu-operator-e2e-24-6-x`

This commit fixes it, so it will trigger the appropriate jobs, you can take a look at my fork to see that it fixed it for example:
https://github.com/TomerNewman/nvidia-ci/pull/9

---

Besides that the comments looks ok so if you see any pr comment that should be fixed please let me know and I will commit it on this pr.

/cc @empovit 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the internal configuration formatting for stable update notifications to ensure clarity and consistency without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->