### PR TITLE
schedule runs will run only on main repo

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -11,6 +11,7 @@ on:
         type: string
 jobs:
   ocp-version:
+    if: (github.event_name == 'schedule' && github.repository == 'rh-ecosystem-edge/nvidia-ci') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
       - name: Check out the Repo


### PR DESCRIPTION
This commits should disable the schedule workflows on the forked repos
/cc @empovit 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the automation logic to ensure internal tasks run only under the appropriate conditions, optimizing the workflow execution without affecting user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->