### PR TITLE
Replace OCP release API

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -1,7 +1,7 @@
 name: Check for new versions
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       branch:
@@ -37,18 +37,20 @@ jobs:
 
         env:
           GH_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OCP_IGNORED_VERSIONS: '["4.11","4.13"]'
+          OCP_IGNORED_VERSIONS_REGEX: "4.[6-9]|4.1[0-1,3]"
           VERSION_FILE_PATH: "workflows/versions.json"
-          TEST_TO_TRIGGER_FILE_PATH: "workflows/generatble-files/tests_to_trigger.txt"
+          TEST_TO_TRIGGER_FILE_PATH: "workflows/generated-files/tests_to_trigger.txt"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          title: "[Automatic] Update versions"
+          title: "[Automatic] Update versions, run ID: ${{ github.run_id }}"
           commit-message: Update versions
+          branch: update-versions/${{ github.run_id }}
           body: |
             :warning: Before approving the PR, run the following tests:
 
-             ```
+            ```
+            /ok-to-test
             ${{ steps.read_tests.outputs.TEST_TRIGGERS }}
             ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/workflows/generatble-files/
+/workflows/generated-files/
 /workflows/__pycache__/

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -2,46 +2,20 @@
 
 ## Fetching OpenShift release versions
 
-Registry URL: [https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags](https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags)
-
-The registry is public and doesn't require authentication. However, it must be used with pagination.
-
-Example using [Red Hat Quay API](https://docs.redhat.com/en/documentation/red_hat_quay/latest/html-single/red_hat_quay_api_guide/index):
+Release URL: [https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/accepted](https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/accepted)
 
 ```console
-curl -SsL "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?limit=100&page=1&onlyActiveTags=true&filter_tag_name=like:4.1%.%-multi-x86_64" -H "Content-Type: application/json" | jq
+curl -SsL "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/accepted" -H "Content-Type: application/json" | jq -r '."4-stable"'
 ```
 
 output:
 
 ```json
 {
-  "tags": [
-    {
-      "name": "4.15.47-multi-x86_64",
-      "reversion": false,
-      "start_ts": 1741359805,
-      "manifest_digest": "sha256:12192f1c49ad70603b19f9ce8f886be14fdd4cf275dfdc2c9c867edf7f2f792d",
-      "is_manifest_list": false,
-      "size": 168953417,
-      "last_modified": "Fri, 07 Mar 2025 15:03:25 -0000"
-    },
-    {
-      ...
-    }
-    },
-    {
-      "name": "4.18.3-multi-x86_64",
-      "reversion": false,
-      "start_ts": 1741102000,
-      "manifest_digest": "sha256:cda3ea1ebc84b5586cb45c61ff7c3dc6ac80a734adee9fb0c0a7d170029058da",
-      "is_manifest_list": false,
-      "size": 182092611,
-      "last_modified": "Tue, 04 Mar 2025 15:26:40 -0000"
-    }
-  ],
-  "page": 1,
-  "has_additional": true
+  "4.18.2",
+  "4.18.1",
+  "4.18.0-rc.10",
+  ...
 }
 ```
 
@@ -102,6 +76,12 @@ output:
 
 ```console
 sha256:e8576f598bfa189085921ea6bf6d8335d78cb5302de51bcd117cfac0428e7665
+```
+
+## How to run unit tests
+
+```console
+for f in workflows/*_test.py; do echo "File: $f"; python "$f"; done
 ```
 
 ## Useful links

--- a/workflows/nvidia_gpu_operator.py
+++ b/workflows/nvidia_gpu_operator.py
@@ -3,29 +3,35 @@ import os
 import re
 
 import requests
-import semver
 
-from utils import get_logger
+
+from settings import settings
+from utils import get_logger, max_version
 
 logger = get_logger(__name__)
 
-gpu_operator_nvcr_auth_url = 'https://nvcr.io/proxy_auth?scope=repository:nvidia/gpu-operator:pull'
-gpu_operator_nvcr_tags_url = 'https://nvcr.io/v2/nvidia/gpu-operator/tags/list'
+GPU_OPERATOR_NVCR_AUTH_URL = 'https://nvcr.io/proxy_auth?scope=repository:nvidia/gpu-operator:pull'
+GPU_OPERATOR_NVCR_TAGS_URL = 'https://nvcr.io/v2/nvidia/gpu-operator/tags/list'
 
-gpu_operator_ghcr_auth_url = 'https://ghcr.io/token?scope=repository:nvidia/gpu-operator:pull'
-gpu_operator_ghcr_latest_url = 'https://ghcr.io/v2/nvidia/gpu-operator/gpu-operator-bundle/manifests/main-latest'
+GPU_OPERATOR_GHCR_AUTH_URL = 'https://ghcr.io/token?scope=repository:nvidia/gpu-operator:pull'
+GPU_OPERATOR_GHCR_LATEST_URL = 'https://ghcr.io/v2/nvidia/gpu-operator/gpu-operator-bundle/manifests/main-latest'
 
 version_not_found = '1.0.0'
 
 def get_operator_versions() -> dict:
 
     logger.info('Calling NVCR authentication API')
-    auth_req = requests.get(gpu_operator_nvcr_auth_url, allow_redirects=True, headers={'Content-Type': 'application/json'})
+    auth_req = requests.get(GPU_OPERATOR_NVCR_AUTH_URL,
+                            allow_redirects=True,
+                            headers={'Content-Type': 'application/json'},
+                            timeout=settings.request_timeout_sec)
     auth_req.raise_for_status()
     token = auth_req.json()['token']
 
     logger.info('Listing tags of the GPU operator image')
-    req = requests.get(gpu_operator_nvcr_tags_url, headers={'Content-Type': 'application/json', 'Authorization': f'Bearer {token}'})
+    req = requests.get(GPU_OPERATOR_NVCR_TAGS_URL,
+                       headers={'Content-Type': 'application/json', 'Authorization': f'Bearer {token}'},
+                       timeout=settings.request_timeout_sec)
     req.raise_for_status()
 
     tags = req.json()['tags']
@@ -43,7 +49,7 @@ def get_operator_versions() -> dict:
         patch = match.group('patch')
         full_version = f'{minor}.{patch}'
         existing = versions.get(minor, version_not_found)
-        versions[minor] = semver.max_ver(existing, full_version)
+        versions[minor] = max_version(existing, full_version)
 
     return versions
 
@@ -54,12 +60,17 @@ def get_sha() -> str:
         logger.info('GH_AUTH_TOKEN env variable is available, using it to authenticate against GitHub')
     else:
         logger.info('GH_AUTH_TOKEN is not available, calling GitHub authentication API')
-        auth_req = requests.get(gpu_operator_ghcr_auth_url, allow_redirects=True, headers={'Content-Type': 'application/json'})
+        auth_req = requests.get(GPU_OPERATOR_GHCR_AUTH_URL,
+                                allow_redirects=True,
+                                headers={'Content-Type': 'application/json'},
+                                timeout=settings.request_timeout_sec)
         auth_req.raise_for_status()
         token = auth_req.json()['token']
 
     logger.info('Getting digest of the GPU operator OLM bundle')
-    req = requests.get(gpu_operator_ghcr_latest_url, headers={'Content-Type': 'application/json', 'Authorization': f'Bearer {token}'})
+    req = requests.get(GPU_OPERATOR_GHCR_LATEST_URL,
+                       headers={'Content-Type': 'application/json', 'Authorization': f'Bearer {token}'},
+                       timeout=settings.request_timeout_sec)
     req.raise_for_status()
     config = req.json()['config']
     logger.debug(f'Received GPU operator bundle config: {config}')

--- a/workflows/openshift.py
+++ b/workflows/openshift.py
@@ -6,44 +6,41 @@ import semver
 
 from settings import settings
 from typing import Pattern, AnyStr
-from utils import get_logger
+from utils import get_logger, max_version
 
 logger = get_logger(__name__)
 
-quay_url_api = 'https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/'
+RELEASE_URL_API = 'https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/accepted'
 
 def fetch_ocp_versions() -> dict:
+    """
+    Fetches accepted OpenShift versions from the release API.
+
+    The function filters out versions based on the regex pattern defined in settings.ignored_versions.
+    For each minor version (e.g., 4.12), only the highest patch version is kept.
+
+    Returns:
+        dict: A dictionary mapping minor versions (e.g., '4.12') to their highest patch version (e.g., '4.12.3').
+    """
+
+    logger.info(f'Ignored versions: {settings.ignored_versions}')
+    ignored_regex: Pattern[AnyStr] = re.compile(settings.ignored_versions)
     versions: dict = {}
-    page_size: int = 100
-    has_more: bool = True
-    tag_filter: str = 'like:%.%.%-multi-x86_64'
-    tag_regex: Pattern[AnyStr] = re.compile(r'^(?P<minor>\d+\.\d+)\.(?P<patch>\d+(?:-rc\.\d+)?)\-multi\-x86_64$')
-    page: int = 1
 
-    while has_more:
-        logger.info(f'Listing OpenShift images, page: {page}')
-        response = requests.get(quay_url_api, params={
-            'limit': str(page_size), 'page': page, 'filter_tag_name': tag_filter, 'onlyActiveTags': 'true'})
-        response.raise_for_status()
-        response_json = response.json()
-        has_more = response_json.get('has_additional')
+    logger.info('Listing accepted OpenShift versions')
+    response = requests.get(RELEASE_URL_API, timeout=settings.request_timeout_sec)
+    response.raise_for_status()
+    accepted_versions = response.json()['4-stable']
+    logger.debug(f'Received OpenShift versions: {accepted_versions}')
 
-        tags = response_json.get('tags', [])
-        logger.debug(f'Received OpenShift image tags: {tags}. Has more: {has_more}. Page: {page}')
-        page += 1
+    for ver in accepted_versions:
+        sem_ver = semver.VersionInfo.parse(ver)
+        minor = f'{sem_ver.major}.{sem_ver.minor}'
+        if ignored_regex.fullmatch(minor):
+            logger.debug(f'Version {ver} ignored')
+            continue
 
-        for tag in tags:
-            tag_name = tag.get('name', '')
-            match = tag_regex.match(tag_name)
-            if not match:
-                continue
-
-            minor = match.group('minor')
-            if minor in settings.ignored_versions:
-                continue
-
-            full = f"{minor}.{match.group('patch')}"
-            patches = versions.get(minor)
-            versions[minor] = semver.max_ver(versions[minor], full) if patches else full
+        patches = versions.get(minor)
+        versions[minor] = max_version(patches, ver) if patches else ver
 
     return versions

--- a/workflows/openshift_test.py
+++ b/workflows/openshift_test.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+import unittest
+from unittest.mock import patch, MagicMock
+from requests.exceptions import RequestException
+
+# Import the module to test
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from workflows.openshift import fetch_ocp_versions, RELEASE_URL_API
+
+
+class TestOpenShift(unittest.TestCase):
+    """Test cases for workflows/openshift.py functions."""
+
+    @patch('workflows.openshift.settings')
+    @patch('workflows.openshift.requests.get')
+    def test_fetch_ocp_versions_basic(self, mock_get, mock_settings):
+        """Test basic functionality of fetch_ocp_versions."""
+        # Mock settings
+        mock_settings.ignored_versions = "x^"  # Regex that matches nothing
+        mock_settings.request_timeout_sec = 30
+
+        # Mock API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'4-stable': ['4.10.1', '4.10.2', '4.11.0', '4.12.3']}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Call the function
+        result = fetch_ocp_versions()
+
+        # Verify the results
+        expected = {
+            '4.10': '4.10.2',  # Highest patch for 4.10
+            '4.11': '4.11.0',  # Only patch for 4.11
+            '4.12': '4.12.3',  # Only patch for 4.12
+        }
+        self.assertEqual(result, expected)
+
+        # Verify the correct URL was called with timeout
+        mock_get.assert_called_once_with(RELEASE_URL_API, timeout=30)
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch('workflows.openshift.settings')
+    @patch('workflows.openshift.requests.get')
+    def test_fetch_ocp_versions_ignored(self, mock_get, mock_settings):
+        """Test that ignored versions are correctly filtered out."""
+        # Mock settings with a regex to ignore 4.10 and 4.12
+        mock_settings.ignored_versions = "4.10|4.12"
+        mock_settings.request_timeout_sec = 30
+
+        # Mock API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'4-stable': ['4.10.1', '4.10.2', '4.11.0', '4.12.3']}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Call the function
+        result = fetch_ocp_versions()
+
+        # Verify only the non-ignored version is included
+        expected = {
+            '4.11': '4.11.0',  # Only 4.11 should remain
+        }
+        self.assertEqual(result, expected)
+
+    @patch('workflows.openshift.settings')
+    @patch('workflows.openshift.requests.get')
+    def test_fetch_ocp_versions_highest_patch(self, mock_get, mock_settings):
+        """Test that highest patch version is selected for each minor version."""
+        # Mock settings
+        mock_settings.ignored_versions = "x^"  # Regex that matches nothing
+        mock_settings.request_timeout_sec = 30
+
+        # Mock API response with multiple patch versions for the same minor version
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'4-stable': [
+            '4.10.0', '4.10.1', '4.10.2', '4.10.1-rc.3',
+            '4.11.5', '4.11.3', '4.11.8', '4.11.4'
+        ]}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Call the function
+        result = fetch_ocp_versions()
+
+        # Verify the highest patch version is selected for each minor version
+        expected = {
+            '4.10': '4.10.2',     # Highest patch for 4.10
+            '4.11': '4.11.8',     # Highest patch for 4.11
+        }
+        self.assertEqual(result, expected)
+
+    @patch('workflows.openshift.settings')
+    @patch('workflows.openshift.requests.get')
+    def test_fetch_ocp_versions_empty_response(self, mock_get, mock_settings):
+        """Test behavior when API returns an empty list of versions."""
+        # Mock settings
+        mock_settings.ignored_versions = "x^"
+        mock_settings.request_timeout_sec = 30
+
+        # Mock empty API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'4-stable': []}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Call the function
+        result = fetch_ocp_versions()
+
+        # Verify the result is an empty dictionary
+        self.assertEqual(result, {})
+
+    @patch('workflows.openshift.settings')
+    @patch('workflows.openshift.requests.get')
+    def test_fetch_ocp_versions_api_error(self, mock_get, mock_settings):
+        """Test error handling when API request fails."""
+        # Mock settings
+        mock_settings.ignored_versions = "x^"
+        mock_settings.request_timeout_sec = 30
+
+        # Mock API error
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = RequestException("API error")
+        mock_get.return_value = mock_response
+
+        # Verify the exception is raised
+        with self.assertRaises(RequestException):
+            fetch_ocp_versions()
+
+    @patch('workflows.openshift.settings')
+    @patch('workflows.openshift.requests.get')
+    def test_fetch_ocp_versions_invalid_response(self, mock_get, mock_settings):
+        """Test behavior when API returns an invalid response structure."""
+        # Mock settings
+        mock_settings.ignored_versions = "x^"
+        mock_settings.request_timeout_sec = 30
+
+        # Mock invalid API response (missing 4-stable key)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'some-other-key': []}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Verify the exception is raised
+        with self.assertRaises(KeyError):
+            fetch_ocp_versions()
+
+    @patch('workflows.openshift.settings')
+    @patch('workflows.openshift.requests.get')
+    def test_fetch_ocp_versions_invalid_semver(self, mock_get, mock_settings):
+        """Test behavior when API returns invalid semver format."""
+        # Mock settings
+        mock_settings.ignored_versions = "x^"
+        mock_settings.request_timeout_sec = 30
+
+        # Mock API response with invalid semver
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'4-stable': ['4.10.1', 'not-a-semver', '4.11.0']}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Call the function - it should skip the invalid version
+        with self.assertRaises(ValueError):
+            fetch_ocp_versions()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/workflows/requirements.txt
+++ b/workflows/requirements.txt
@@ -1,2 +1,2 @@
-semver==2.13.0
+semver==3.0.4
 requests==2.32.3

--- a/workflows/settings.py
+++ b/workflows/settings.py
@@ -1,14 +1,15 @@
-import json
 import os
 
 class Settings:
-    ignored_versions: list[str]
+    ignored_versions: str
     version_file_path: str
     tests_to_trigger_file_path: str
+    request_timeout_sec: int
 
     def __init__(self):
-        self.ignored_versions = json.loads(os.getenv("OCP_IGNORED_VERSIONS", "[]"))
+        self.ignored_versions = os.getenv("OCP_IGNORED_VERSIONS_REGEX", "x^").rstrip()
         self.version_file_path = os.getenv("VERSION_FILE_PATH")
         self.tests_to_trigger_file_path = os.getenv("TEST_TO_TRIGGER_FILE_PATH")
+        self.request_timeout_sec = int(os.getenv("REQUEST_TIMEOUT_SECONDS", 30))
 
 settings = Settings()

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from logging import Logger
+from semver import Version
 from typing import Any
 
 test_command_template = "/test {ocp_version}-stable-nvidia-gpu-operator-e2e-{gpu_version}"
@@ -99,3 +100,10 @@ def calculate_diffs(old_versions: dict, new_versions: dict) -> dict:
 
 def version2suffix(v: str):
     return v if v == 'master' else f'{v.replace(".", "-")}-x'
+
+def max_version(a: str, b: str) -> str:
+    """
+    Parse and compare two semver versions.
+    Return the higher of them.
+    """
+    return str(max(map(Version.parse, (a, b))))


### PR DESCRIPTION
* Use the API that is aligned with the test platform. It's also much simpler.
* Use a regex for ignored OCP versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a regex-based approach for defining ignored OpenShift versions, enhancing flexibility.
  - Simplified the retrieval process for accepted OpenShift versions from a new API endpoint.
  - Added a timestamp to pull request titles and established a new branch naming convention.
  - Added a new section in the documentation for running unit tests.

- **Bug Fixes**
  - Corrected the path for the test trigger file in the workflow configuration.
  - Fixed a typographical error in the directory name for ignored files in the `.gitignore`.

- **Refactor**
  - Updated the type declaration for ignored versions from a list to a string for better clarity and usage.
  - Enhanced HTTP request robustness by adding timeout parameters to various requests.
  - Changed variable names to uppercase to reflect a constant naming convention.
  - Introduced a new function for comparing semantic versioning strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->