### PR TITLE
updates to support creating NNO macvlannetwork CR

### DIFF
--- a/internal/wait/networkwait.go
+++ b/internal/wait/networkwait.go
@@ -18,7 +18,7 @@ func NicClusterPolicyReady(apiClient *clients.Settings, nicClusterPolicyName str
 	timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.Background(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			nicClusterPolicy, err := nvidianetwork.Pull(apiClient, nicClusterPolicyName)
+			nicClusterPolicy, err := nvidianetwork.PullNicClusterPolicy(apiClient, nicClusterPolicyName)
 
 			if err != nil {
 				glog.V(networkparams.LogLevel).Infof("NicClusterPolicy pull from cluster error: %s\n", err)
@@ -31,5 +31,26 @@ func NicClusterPolicyReady(apiClient *clients.Settings, nicClusterPolicyName str
 
 			// returns true, nil when NicClusterPolicy is ready, this exits out of the PollUntilContextTimeout()
 			return nicClusterPolicy.Object.Status.State == networkoperator.StateReady, nil
+		})
+}
+
+// MacvlanNetworkReady Waits until macvlanNetwork is Ready.
+func MacvlanNetworkReady(apiClient *clients.Settings, macvlanNetworkName string, pollInterval,
+	timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(
+		context.Background(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+			macVlanNetwork, err := nvidianetwork.PullMacvlanNetwork(apiClient, macvlanNetworkName)
+
+			if err != nil {
+				glog.V(networkparams.LogLevel).Infof("MacvlanNetwork pull from cluster error: %s\n", err)
+
+				return false, err
+			}
+
+			glog.V(networkparams.LogLevel).Infof("MacvlanNetwork %s in now in %s state",
+				macVlanNetwork.Object.Name, macVlanNetwork.Object.Status.State)
+
+			// returns true, nil when NicClusterPolicy is ready, this exits out of the PollUntilContextTimeout()
+			return macVlanNetwork.Object.Status.State == networkoperator.StateReady, nil
 		})
 }

--- a/pkg/nvidianetwork/macvlannetwork.go
+++ b/pkg/nvidianetwork/macvlannetwork.go
@@ -1,0 +1,282 @@
+package nvidianetwork
+
+import (
+	"context"
+	"fmt"
+	nvidianetworkv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
+
+	"github.com/golang/glog"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/msg"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MacvlanNetworkBuilder  provides a struct for MacvlanNetwork object
+// from the cluster and a MacvlanNetwork definition.
+type MacvlanNetworkBuilder struct {
+	// MacvlanNetworkBuilder  definition. Used to create
+	// MacvlanNetworkBuilder  object with minimum set of required elements.
+	Definition *nvidianetworkv1alpha1.MacvlanNetwork
+	// Created MacvlanNetworkBuilder  object on the cluster.
+	Object *nvidianetworkv1alpha1.MacvlanNetwork
+	// api client to interact with the cluster.
+	apiClient *clients.Settings
+	// errorMsg is processed before MacvlanNetworkBuilder  object is created.
+	errorMsg string
+}
+
+// NewMacvlanNetworkBuilderFromObjectString creates a MacvlanNetworkBuilder  object from CSV alm-examples.
+func NewMacvlanNetworkBuilderFromObjectString(apiClient *clients.Settings, almExample string) *MacvlanNetworkBuilder {
+	glog.V(100).Infof(
+		"Initializing new MacvlanNetworkBuilder  structure from almExample string")
+
+	macvlanNetwork, err := getMacvlanNetworkFromAlmExample(almExample)
+
+	if err != nil {
+		glog.V(100).Infof(
+			"Error initializing MacvlanNetwork from alm-examples: %s", err.Error())
+
+		builder := MacvlanNetworkBuilder{
+			apiClient: apiClient,
+			errorMsg:  fmt.Sprintf("Error initializing MacvlanNetwork from alm-examples: %s", err.Error()),
+		}
+
+		return &builder
+	}
+
+	if macvlanNetwork == nil {
+		builder := MacvlanNetworkBuilder{
+			apiClient: apiClient,
+			errorMsg:  "MacvlanNetwork is nil after parsing almExample",
+		}
+		return &builder
+	}
+
+	glog.V(100).Infof(
+		"Initializing new MacvlanNetworkBuilder  structure from almExample string with MacvlanNetwork name: %s",
+		macvlanNetwork.Name)
+
+	builder := MacvlanNetworkBuilder{
+		apiClient:  apiClient,
+		Definition: macvlanNetwork,
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The MacvlanNetwork object definition is nil")
+
+		builder.errorMsg = "MacvlanNetwork 'Object.Definition' is nil"
+	}
+
+	return &builder
+}
+
+// Get returns MacvlanNetwork object if found.
+func (builder *MacvlanNetworkBuilder) Get() (*nvidianetworkv1alpha1.MacvlanNetwork, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof(
+		"Collecting MacvlanNetwork object %s", builder.Definition.Name)
+
+	MacvlanNetwork := &nvidianetworkv1alpha1.MacvlanNetwork{}
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
+		Name: builder.Definition.Name,
+	}, MacvlanNetwork)
+
+	if err != nil {
+		glog.V(100).Infof(
+			"MacvlanNetwork object %s doesn't exist", builder.Definition.Name)
+
+		return nil, err
+	}
+
+	return MacvlanNetwork, err
+}
+
+// PullMacvlanNetwork loads an existing MacvlanNetwork into MacvlanNetworkBuilder  struct.
+func PullMacvlanNetwork(apiClient *clients.Settings, name string) (*MacvlanNetworkBuilder, error) {
+	glog.V(100).Infof("Pulling existing MacvlanNetwork name: %s", name)
+
+	builder := MacvlanNetworkBuilder{
+		apiClient: apiClient,
+		Definition: &nvidianetworkv1alpha1.MacvlanNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("MacvlanNetwork name is empty")
+
+		builder.errorMsg = "MacvlanNetwork 'name' cannot be empty"
+		return nil, fmt.Errorf(builder.errorMsg)
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("MacvlanNetwork object %s doesn't exist", name)
+	}
+
+	builder.Definition = builder.Object
+
+	return &builder, nil
+}
+
+// Exists checks whether the given MacvlanNetwork exists.
+func (builder *MacvlanNetworkBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof(
+		"Checking if MacvlanNetwork %s exists", builder.Definition.Name)
+
+	var err error
+	builder.Object, err = builder.Get()
+
+	if err != nil {
+		glog.V(100).Infof("Failed to collect MacvlanNetwork object due to %s", err.Error())
+	}
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Delete removes a MacvlanNetwork.
+func (builder *MacvlanNetworkBuilder) Delete() (*MacvlanNetworkBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Deleting MacvlanNetwork %s", builder.Definition.Name)
+
+	if !builder.Exists() {
+		return builder, fmt.Errorf("MacvlanNetwork cannot be deleted because it does not exist")
+	}
+
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
+
+	if err != nil {
+		return builder, fmt.Errorf("cannot delete MacvlanNetwork: %w", err)
+	}
+
+	builder.Object = nil
+
+	return builder, nil
+}
+
+// Create makes a MacvlanNetwork in the cluster and stores the created object in struct.
+func (builder *MacvlanNetworkBuilder) Create() (*MacvlanNetworkBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Creating the MacvlanNetwork %s", builder.Definition.Name)
+
+	var err error
+	if !builder.Exists() {
+		err = builder.apiClient.Create(context.TODO(), builder.Definition)
+
+		if err == nil {
+			builder.Object = builder.Definition
+		} else {
+			glog.V(100).Infof("Error creating the MacvlanNetwork '%s' : '%s'",
+				builder.Definition.Name, err.Error())
+		}
+	}
+
+	return builder, err
+}
+
+// Update renovates the existing MacvlanNetwork object with the definition in builder.
+func (builder *MacvlanNetworkBuilder) Update(force bool) (*MacvlanNetworkBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Updating the MacvlanNetwork object named:  %s", builder.Definition.Name)
+
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
+
+	if err != nil {
+		if force {
+			glog.V(100).Infof(msg.FailToUpdateNotification("MacvlanNetwork", builder.Definition.Name))
+
+			builder, err := builder.Delete()
+
+			if err != nil {
+				glog.V(100).Infof(
+					msg.FailToUpdateError("MacvlanNetwork", builder.Definition.Name))
+
+				return nil, err
+			}
+
+			return builder.Create()
+		}
+	}
+
+	return builder, err
+}
+
+// getMacvlanNetworkFromAlmExample extracts the MacvlanNetwork from the alm-examples block.
+func getMacvlanNetworkFromAlmExample(almExample string) (*nvidianetworkv1alpha1.MacvlanNetwork, error) {
+	MacvlanNetworkList := &nvidianetworkv1alpha1.MacvlanNetworkList{}
+
+	if almExample == "" {
+		return nil, fmt.Errorf("almExample is an empty string")
+	}
+
+	err := json.Unmarshal([]byte(almExample), &MacvlanNetworkList.Items)
+
+	if err != nil {
+		glog.V(100).Infof("Error unmarshalling MacvlanNetwork from almExamples: '%s'", err.Error())
+
+		return nil, err
+	}
+
+	if len(MacvlanNetworkList.Items) == 0 {
+		return nil, fmt.Errorf("failed to get alm examples")
+	}
+
+	for i := range MacvlanNetworkList.Items {
+		if MacvlanNetworkList.Items[i].Kind == "MacvlanNetwork" {
+			return &MacvlanNetworkList.Items[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("MacvlanNetwork not found in alm examples")
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *MacvlanNetworkBuilder) validate() (bool, error) {
+	resourceCRD := nvidianetworkv1alpha1.MacvlanNetworkCRDName
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/pkg/nvidianetwork/nicclusterpolicy.go
+++ b/pkg/nvidianetwork/nicclusterpolicy.go
@@ -14,24 +14,24 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Builder provides a struct for NicClusterPolicy object
+// NicClusterPolicyBuilder provides a struct for NicClusterPolicy object
 // from the cluster and a NicClusterPolicy definition.
-type Builder struct {
-	// Builder definition. Used to create
-	// Builder object with minimum set of required elements.
+type NicClusterPolicyBuilder struct {
+	// NicClusterPolicyBuilder definition. Used to create
+	// NicClusterPolicyBuilder object with minimum set of required elements.
 	Definition *nvidianetworkv1alpha1.NicClusterPolicy
-	// Created Builder object on the cluster.
+	// Created NicClusterPolicyBuilder object on the cluster.
 	Object *nvidianetworkv1alpha1.NicClusterPolicy
 	// api client to interact with the cluster.
 	apiClient *clients.Settings
-	// errorMsg is processed before Builder object is created.
+	// errorMsg is processed before NicClusterPolicyBuilder object is created.
 	errorMsg string
 }
 
-// NewBuilderFromObjectString creates a Builder object from CSV alm-examples.
-func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) *Builder {
+// NewNicClusterPolicyBuilderFromObjectString creates a NicClusterPolicyBuilder object from CSV alm-examples.
+func NewNicClusterPolicyBuilderFromObjectString(apiClient *clients.Settings, almExample string) *NicClusterPolicyBuilder {
 	glog.V(100).Infof(
-		"Initializing new Builder structure from almExample string")
+		"Initializing new NicClusterPolicyBuilder structure from almExample string")
 
 	nicClusterPolicy, err := getNicClusterPolicyFromAlmExample(almExample)
 
@@ -39,7 +39,7 @@ func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) 
 		glog.V(100).Infof(
 			"Error initializing NicClusterPolicy from alm-examples: %s", err.Error())
 
-		builder := Builder{
+		builder := NicClusterPolicyBuilder{
 			apiClient: apiClient,
 			errorMsg:  fmt.Sprintf("Error initializing NicClusterPolicy from alm-examples: %s", err.Error()),
 		}
@@ -48,7 +48,7 @@ func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) 
 	}
 
 	if nicClusterPolicy == nil {
-		builder := Builder{
+		builder := NicClusterPolicyBuilder{
 			apiClient: apiClient,
 			errorMsg:  "NicClusterPolicy is nil after parsing almExample",
 		}
@@ -56,10 +56,10 @@ func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) 
 	}
 
 	glog.V(100).Infof(
-		"Initializing new Builder structure from almExample string with NicClusterPolicy name: %s",
+		"Initializing new NicClusterPolicyBuilder structure from almExample string with NicClusterPolicy name: %s",
 		nicClusterPolicy.Name)
 
-	builder := Builder{
+	builder := NicClusterPolicyBuilder{
 		apiClient:  apiClient,
 		Definition: nicClusterPolicy,
 	}
@@ -74,7 +74,7 @@ func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) 
 }
 
 // Get returns nicclusterPolicy object if found.
-func (builder *Builder) Get() (*nvidianetworkv1alpha1.NicClusterPolicy, error) {
+func (builder *NicClusterPolicyBuilder) Get() (*nvidianetworkv1alpha1.NicClusterPolicy, error) {
 	if valid, err := builder.validate(); !valid {
 		return nil, err
 	}
@@ -97,11 +97,11 @@ func (builder *Builder) Get() (*nvidianetworkv1alpha1.NicClusterPolicy, error) {
 	return nicClusterPolicy, err
 }
 
-// Pull loads an existing NicClusterPolicy into Builder struct.
-func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
+// PullNicClusterPolicy loads an existing NicClusterPolicy into NicClusterPolicyBuilder struct.
+func PullNicClusterPolicy(apiClient *clients.Settings, name string) (*NicClusterPolicyBuilder, error) {
 	glog.V(100).Infof("Pulling existing nicClusterPolicy name: %s", name)
 
-	builder := Builder{
+	builder := NicClusterPolicyBuilder{
 		apiClient: apiClient,
 		Definition: &nvidianetworkv1alpha1.NicClusterPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +127,7 @@ func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
 }
 
 // Exists checks whether the given NicClusterPolicy exists.
-func (builder *Builder) Exists() bool {
+func (builder *NicClusterPolicyBuilder) Exists() bool {
 	if valid, _ := builder.validate(); !valid {
 		return false
 	}
@@ -146,7 +146,7 @@ func (builder *Builder) Exists() bool {
 }
 
 // Delete removes a NicClusterPolicy.
-func (builder *Builder) Delete() (*Builder, error) {
+func (builder *NicClusterPolicyBuilder) Delete() (*NicClusterPolicyBuilder, error) {
 	if valid, err := builder.validate(); !valid {
 		return builder, err
 	}
@@ -169,7 +169,7 @@ func (builder *Builder) Delete() (*Builder, error) {
 }
 
 // Create makes a NicClusterPolicy in the cluster and stores the created object in struct.
-func (builder *Builder) Create() (*Builder, error) {
+func (builder *NicClusterPolicyBuilder) Create() (*NicClusterPolicyBuilder, error) {
 	if valid, err := builder.validate(); !valid {
 		return builder, err
 	}
@@ -192,7 +192,7 @@ func (builder *Builder) Create() (*Builder, error) {
 }
 
 // Update renovates the existing NicClusterPolicy object with the definition in builder.
-func (builder *Builder) Update(force bool) (*Builder, error) {
+func (builder *NicClusterPolicyBuilder) Update(force bool) (*NicClusterPolicyBuilder, error) {
 	if valid, err := builder.validate(); !valid {
 		return builder, err
 	}
@@ -252,7 +252,7 @@ func getNicClusterPolicyFromAlmExample(almExample string) (*nvidianetworkv1alpha
 
 // validate will check that the builder and builder definition are properly initialized before
 // accessing any member fields.
-func (builder *Builder) validate() (bool, error) {
+func (builder *NicClusterPolicyBuilder) validate() (bool, error) {
 	resourceCRD := nvidianetworkv1alpha1.NicClusterPolicyCRDName
 	if builder == nil {
 		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)


### PR DESCRIPTION
Adding support to create the MacvlanNetwork CR needed for shared device RDMA tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for macvlan network lifecycle management, including creation, retrieval, deletion, and readiness checking.
- **Refactor**
  - Improved naming and clarity for network policy management functions.
- **Tests**
  - Enhanced deployment tests to incorporate macvlan network operations alongside existing network policy management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->