### PR TITLE
Test GPU operator bundle with earliest supported OpenShift

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -50,8 +50,9 @@ jobs:
             :warning: Before approving the PR, run the following tests:
 
             ```
-            /ok-to-test
             ${{ steps.read_tests.outputs.TEST_TRIGGERS }}
+            /ok-to-test
+            /approve
             ```
 
             Update the NVIDIA GPU operator on OpenShift test matrix

--- a/workflows/update_versions_test.py
+++ b/workflows/update_versions_test.py
@@ -14,6 +14,7 @@ base_versions = {
     }
 }
 
+
 class TestCalculateDiffs(unittest.TestCase):
 
     def test_bundle_key_created(self):
@@ -58,7 +59,7 @@ class TestCalculateDiffs(unittest.TestCase):
 
     def test_ocp_version_key_created(self):
         old_versions = {}
-        new_versions = {'ocp':{'4.12': '4.12.2'}}
+        new_versions = {'ocp': {'4.12': '4.12.2'}}
         diff = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'ocp': {'4.12': '4.12.2'}})
 
@@ -83,12 +84,14 @@ class TestCalculateDiffs(unittest.TestCase):
         diff = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {})
 
+
 class TestCreateTestsMatrix(unittest.TestCase):
 
     def test_bundle_changed(self):
         diff = {'gpu-main-latest': 'B'}
-        tests = create_tests_matrix(diff, ['4.11', '4.13'], ['21.3', '22.3'])
-        self.assertEqual(tests, {('4.13', 'master')})
+        tests = create_tests_matrix(
+            diff, ['4.14', '4.10', '4.11', '4.13'], ['21.3', '22.3'])
+        self.assertEqual(tests, {('4.14', 'master'), ('4.10', 'master')})
 
     def test_gpu_version_changed(self):
         diff = {'gpu-operator': {'25.1': '25.1.1'}}
@@ -107,7 +110,8 @@ class TestCreateTestsMatrix(unittest.TestCase):
 
     def test_ocp_version_added(self):
         diff = {'ocp': {'4.15': '4.15.0'}}
-        tests = create_tests_matrix(diff, ['4.12', '4.13', '4.15'], ['24.4', '25.3'])
+        tests = create_tests_matrix(
+            diff, ['4.12', '4.13', '4.15'], ['24.4', '25.3'])
         self.assertEqual(tests, {('4.15', '24.4'), ('4.15', '25.3')})
 
     def test_no_changes(self):

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -36,9 +36,15 @@ def update_key(versions_file: str, version_key: str, version_value: Any):
 
 
 def get_latest_versions(versions: list, count: int) -> list:
-    sorted_versions = sorted(versions, key=lambda v: tuple(map(int, v.split('.'))))
+    sorted_versions = get_sorted_versions(versions)
     return sorted_versions[-count:] if len(sorted_versions) > count else sorted_versions
 
+def get_earliest_versions(versions: list, count: int) -> list:
+    sorted_versions = get_sorted_versions(versions)
+    return sorted_versions[:count] if len(sorted_versions) > count else sorted_versions
+
+def get_sorted_versions(versions: list) -> list:
+    return sorted(versions, key=lambda v: tuple(map(int, v.split('.'))))
 
 def save_tests_commands(tests_commands: set, file_path: str):
     with open(file_path, "w+") as f:
@@ -51,6 +57,9 @@ def create_tests_matrix(diffs: dict, ocp_releases: list, gpu_releases: list) -> 
     if "gpu-main-latest" in diffs:
         latest_ocp = get_latest_versions(ocp_releases, 1)
         for ocp_version in latest_ocp:
+            tests.add((ocp_version, "master"))
+        earliest_ocp = get_earliest_versions(ocp_releases, 1)
+        for ocp_version in earliest_ocp:
             tests.add((ocp_version, "master"))
 
     if "ocp" in diffs:

--- a/workflows/utils_test.py
+++ b/workflows/utils_test.py
@@ -1,5 +1,5 @@
 import unittest
-from utils import get_latest_versions
+from utils import get_latest_versions, get_earliest_versions
 
 class TestGetLatestVersions(unittest.TestCase):
 
@@ -26,6 +26,33 @@ class TestGetLatestVersions(unittest.TestCase):
     def test_reverse_order(self):
         versions = ['1.3', '1.2', '1.1']
         self.assertEqual(get_latest_versions(versions, 3), ['1.1', '1.2', '1.3'])
+
+class TestGetEarliestVersions(unittest.TestCase):
+
+    def test_empty(self):
+        versions = []
+        self.assertEqual(get_earliest_versions(versions, 2), [])
+
+    def test_less_than_count(self):
+        versions = ['1.1']
+        self.assertEqual(get_earliest_versions(versions, 2), ['1.1'])
+
+    def test_exact_count(self):
+        versions = ['1.2', '1.1']
+        self.assertEqual(get_earliest_versions(versions, 2), ['1.1', '1.2'])
+
+    def test_more_than_count(self):
+        versions = ['1.2', '1.3', '1.1']
+        self.assertEqual(get_earliest_versions(versions, 2), ['1.1', '1.2'])
+
+    def test_count_one(self):
+        versions = ['1.3', '1.1', '1.2']
+        self.assertEqual(get_earliest_versions(versions, 1), ['1.1'])
+
+    def test_reverse_order(self):
+        versions = ['1.3', '1.2', '1.1']
+        self.assertEqual(get_earliest_versions(versions, 3), ['1.1', '1.2', '1.3'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Run with earliest OpenShift in addition to latest
* Include `lgtm` and `approve` in test commands for less typing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced pull request guidance by adding an additional command (/approve) to streamline the approval process.
	- Improved version handling by introducing refined methods for selecting both the earliest and latest versions.

- **Tests**
	- Expanded automated tests to cover a broader range of scenarios for the earliest version selection, ensuring reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->