### PR TITLE
Create a test matrix for pre-submit CI jobs(#210)

### DIFF
--- a/.github/workflows/generate_matrix_page.yaml
+++ b/.github/workflows/generate_matrix_page.yaml
@@ -1,0 +1,86 @@
+name: Generate test matrices pages
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to check out'
+        default: 'main'
+        required: false
+        type: string
+      pr_number:
+        description: 'PR number to process (must be specified as a number or "all")'
+        required: true
+        type: string
+
+jobs:
+  generate-matrix:
+    if: github.event_name != 'pull_request' || (github.repository == 'rh-ecosystem-edge/nvidia-ci' && github.event.pull_request.merged == true) 
+    runs-on: ubuntu-latest
+    env:
+      OUTPUT_DIR: 'workflows/test_matrix_dashboard/output'
+      OLD_OCP_FILE: 'old_ocp_data.json'
+      OCP_FILE: 'ocp_data.json'
+      HTML_FILE: 'gpu_operator_matrix.html'
+    steps:
+      - name: Determine PR Number
+        id: determine_pr
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "Processing merged pull request."
+              echo "PR_NUMBER=${{github.event.pull_request.number}}" >> "$GITHUB_OUTPUT"
+          else
+              echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
+
+      - name: Checkout baseline
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: baseline
+
+      - name: Rename and move ${{ env.OCP_FILE }} to ${{ env.OUTPUT_DIR }}/${{ env.OLD_OCP_FILE }}
+        run: |
+          mkdir -p "${{ env.OUTPUT_DIR }}"
+          cp baseline/${{ env.OCP_FILE }} "${{ env.OUTPUT_DIR }}/${{ env.OLD_OCP_FILE }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Dependencies
+        run: |
+          pip install -r workflows/test_matrix_dashboard/requirements.txt
+
+      - name: Run Extraction Script
+        run: |
+          echo "Processing PR: ${{ steps.determine_pr.outputs.PR_NUMBER }}"
+          python workflows/test_matrix_dashboard/generate_test_matrix_data.py \
+            --pr "${{ steps.determine_pr.outputs.PR_NUMBER }}" \
+            --output_dir "${{ env.OUTPUT_DIR }}" \
+            --old_data_file "${{ env.OLD_OCP_FILE }}" \
+            --new_data_file "${{ env.OCP_FILE }}"
+
+      - name: Generate UI
+        run: |
+          python workflows/test_matrix_dashboard/generate_test_matrix_ui.py \
+            --output_dir "${{ env.OUTPUT_DIR }}" \
+            --data_file "${{ env.OCP_FILE }}" \
+            --output_file "${{ env.HTML_FILE }}"
+
+      - name: Deploy HTML to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: ${{ env.OUTPUT_DIR }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /workflows/generated-files/
-/workflows/__pycache__/
+__pycache__/
+venv/
+*.pyc

--- a/workflows/test_matrix_dashboard/README.md
+++ b/workflows/test_matrix_dashboard/README.md
@@ -1,0 +1,165 @@
+
+# NVIDIA GPU Operator Matrix – Dashboard
+
+This directory contains the scripts, data, and supporting files used to **generate** and **deploy** a test matrix for the NVIDIA GPU Operator on Red Hat OpenShift.
+
+---
+
+## Contents
+ignore this comment
+1. **`output/ocp_data.json`**  
+   - Stores summarized test results for various OCP versions and GPU Operator runs (including “bundle”/“master” runs and stable releases).  
+   - Gets updated by the **`generate_test_matrix_data.py`** script, which fetches results from web APIs.
+
+2. **`generate_test_matrix_data.py`**  
+   - A Python script that **fetches** the latest test data and **generates** `ocp_data.json`.  
+   - May be triggered by a GitHub Actions workflow whenever a pull request is merged.
+
+3. **`generate_test_matrix_ui.py`**  
+   - Reads `ocp_data.json` and **generates** an HTML dashboard summarizing pass/fail statuses across OCP versions, GPU Operator versions, etc.  
+   - Outputs an **`index.html`** file (by default in `workflows/test_matrix_dashboard/output/index.html`).
+
+4. **`requirements.txt`**  
+   - Lists Python dependencies required by the above scripts (e.g., `requests`).  
+
+   - Install them with:
+     ```bash
+     pip install -r requirements.txt
+     ```
+
+
+## How to Use Locally
+
+1. **Install Dependencies**  
+   ```bash
+   pip install -r workflows/test_matrix_dashboard/requirements.txt
+   ```
+   *(Adjust the path if your `requirements.txt` is in a different location.)*
+
+2. **First Run (No Previous Data)**  
+   If you don’t have an existing `ocp_data.json`, you can pass any placeholder name to the `--old_data_file` parameter (even if it doesn’t exist yet):
+   ```bash
+   python workflows/test_matrix_dashboard/generate_test_matrix_data.py \
+     --pr "95" \
+     --output_dir "workflows/test_matrix_dashboard/output" \
+     --old_data_file "old_ocp_data.json"
+   ```
+
+3. **Subsequent Runs (With Existing Data)**  
+   If you already have data in `old_ocp_data.json` (for example, from a previous run):
+   ```bash
+   # Ensure the old data file is in the output directory:
+   cp ocp_data.json workflows/test_matrix_dashboard/output/old_ocp_data.json
+
+   # Then run:
+   python workflows/test_matrix_dashboard/generate_test_matrix_data.py \
+     --pr "105" \
+     --output_dir "workflows/test_matrix_dashboard/output" \
+     --old_data_file "old_ocp_data.json"
+   ```
+
+4. **Generate the UI**  
+   After you have an updated `ocp_data.json`, generate the HTML dashboard:
+   ```bash
+   python workflows/test_matrix_dashboard/generate_test_matrix_ui.py \
+     --output_dir "workflows/test_matrix_dashboard/output"
+   ```
+   This creates an `index.html` inside the specified output folder.
+
+5. **Deploy**  
+   If you use [gh-pages](https://www.npmjs.com/package/gh-pages) for deployment:
+   ```bash
+   gh-pages -d workflows/test_matrix_dashboard/output
+   ```
+   This publishes the `output` folder to the `gh-pages` branch on GitHub (or whichever branch you configure for GitHub Pages).
+
+---
+
+## Local Workflow Example
+
+1. **Navigate** to the directory:
+   ```bash
+   cd workflows/test_matrix_dashboard
+
+   ```
+2. **Install** Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Update Test Data**:
+   ```bash
+   python generate_test_matrix_data.py \
+     --pr "105" \
+     --old_data_file "old_ocp_data.json" \
+     --output_dir "output"
+   ```
+   - This updates **`ocp_data.json`** with fresh results.
+4. **Generate the HTML Dashboard**:
+   ```bash
+   python generate_test_matrix_ui.py --output_dir "output"
+   ```
+   - This writes **`index.html`** to **`output/index.html`**.
+5. **Open the Dashboard**:
+   ```bash
+   xdg-open output/index.html
+   ```
+   *(Replace `xdg-open` with the appropriate command on your OS, such as `open` on macOS.)*
+
+---
+
+## GitHub Actions Workflow (CI/CD)
+
+The following GitHub Actions workflow automates the process of updating test data, generating the dashboard UI, and deploying the updated pages to GitHub Pages. Below is an explanation of each step in the workflow.
+
+### Workflow Explanation
+
+**Workflow Name:** *Generate test matrices pages*
+
+**Trigger Conditions:**
+- **Pull Request (Closed on Main):** Runs when a pull request targeting the `main` branch is closed.
+- **Manual Dispatch:** Can also be triggered manually with inputs for the branch to check out and the PR number to process.
+
+**Job: generate-matrix**
+
+1. **Determine PR Number:**  
+   - *Purpose:* Sets the PR number to process.  
+   - *Details:*  
+     - If triggered by a pull request closure, the workflow sets `PR_NUMBER=all` to process all PR history.  
+     - If manually triggered, it expects a valid PR number (or "all"). If none is provided, it errors out.
+
+2. **Checkout Code:**  
+   - *Purpose:* Retrieves the code for the triggering branch (or a specified branch).  
+   - *Details:* Uses the `actions/checkout@v4` action to pull the code.
+
+3. **Checkout Baseline (gh-pages):**  
+   - *Purpose:* Checks out the `gh-pages` branch to obtain the current version of `ocp_data.json`.  
+   - *Details:* Uses sparse checkout to retrieve only the `ocp_data.json` file, saving time and bandwidth.
+
+4. **Rename and Move File:**  
+   - *Purpose:* Prepares the baseline data by renaming `ocp_data.json` to `old_ocp_data.json`.  
+   - *Details:* Copies the file from the baseline folder into the workspace with the new name.
+
+5. **Set Up Python Environment:**  
+   - *Purpose:* Ensures the correct Python version (3.13) is installed.  
+   - *Details:* Uses the `actions/setup-python@v5` action.
+
+6. **Install Dependencies:**  
+   - *Purpose:* Installs all necessary Python libraries.  
+   - *Details:* Runs `pip install -r workflows/test_matrix_dashboard/requirements.txt`.
+
+7. **Run Extraction Script:**  
+   - *Purpose:* Executes the script to extract test data and generate an updated `ocp_data.json`.  
+   - *Details:* Runs `generate_test_matrix_data.py` with parameters including the PR number, output directory, and the old data file.
+
+8. **Archive Old Data:**  
+   - *Purpose:* Archives the old data file (`old_ocp_data.json`) by copying it into the output directory.  
+   - *Details:* Ensures that the previous data is saved alongside the new data.
+
+9. **Generate UI:**  
+   - *Purpose:* Generates an updated HTML dashboard using the new `ocp_data.json`.  
+   - *Details:* Executes `generate_test_matrix_ui.py` to create an `index.html` file.
+
+10. **Deploy HTML to GitHub Pages:**  
+    - *Purpose:* Publishes the generated HTML and updated data to GitHub Pages.  
+    - *Details:* Uses the [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action) to deploy the contents of the output directory to the `gh-pages` branch.

--- a/workflows/test_matrix_dashboard/generate_test_matrix_data.py
+++ b/workflows/test_matrix_dashboard/generate_test_matrix_data.py
@@ -1,0 +1,221 @@
+import argparse
+import json
+import os
+import re
+import urllib.parse
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+import requests
+from logger import logger
+
+BASE_URL = "https://storage.googleapis.com/storage/v1/b/test-platform-results/o"
+
+# Regular expression to match test result paths.
+TEST_PATTERN = re.compile(
+    r"pr-logs/pull/rh-ecosystem-edge_nvidia-ci/\d+/pull-ci-rh-ecosystem-edge-nvidia-ci-main-"
+    r"(?P<ocp_version>\d+\.\d+)-stable-nvidia-gpu-operator-e2e-(?P<gpu_version>\d+-\d+-x|master)/"
+)
+
+# --- Helper Functions ---
+
+def raise_error(message: str) -> None:
+    logger.error(message)
+    raise Exception(message)
+
+def make_request(url: str, params: Dict[str, Any] = None, headers: Dict[str, str] = None) -> Dict[str, Any]:
+    """Send an HTTP GET request and return the JSON response."""
+    response = requests.get(url, params=params, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_file_content(file_path: str) -> str:
+    """Fetch the raw text content from a file in GCS."""
+    logger.info(f"Fetching file content for {file_path}")
+    response = requests.get(
+        url=f"{BASE_URL}/{urllib.parse.quote_plus(file_path)}",
+        params={"alt": "media"},
+    )
+    response.raise_for_status()
+    return response.content.decode("UTF-8")
+
+
+def gpu_suffix_to_version(gpu: str) -> str:
+    """Convert GPU suffix to a version string, e.g., '14-9-x' -> '14.9'."""
+    return gpu if gpu == "master" else gpu[:-2].replace("-", ".")
+
+def get_job_url(pr_id: str, ocp_minor: str, gpu_suffix: str, job_id: str) -> str:
+    """Build the Prow job URL for the given PR, OCP version, GPU suffix, and job ID."""
+    return (
+        f"https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/"
+        f"pull/rh-ecosystem-edge_nvidia-ci/{pr_id}/pull-ci-rh-ecosystem-edge-nvidia-ci-main-"
+        f"{ocp_minor}-stable-nvidia-gpu-operator-e2e-{gpu_suffix}/{job_id}"
+    )
+
+def get_versions(prefix: str, build_id: str, gpu_version_suffix: str) -> Tuple[str, str]:
+    """Fetch the exact OCP and GPU versions for a given build."""
+    logger.info(f"Fetching versions for build {build_id}")
+    ocp_version_file = (
+        f"{prefix}{build_id}/artifacts/nvidia-gpu-operator-e2e-{gpu_version_suffix}/"
+        "gpu-operator-e2e/artifacts/ocp.version"
+    )
+    gpu_version_file = (
+        f"{prefix}{build_id}/artifacts/nvidia-gpu-operator-e2e-{gpu_version_suffix}/"
+        "gpu-operator-e2e/artifacts/operator.version"
+    )
+    ocp_version = fetch_file_content(ocp_version_file)
+    gpu_version = fetch_file_content(gpu_version_file)
+    return ocp_version, gpu_version
+
+
+def get_status_and_time(prefix: str, latest_build_id: str) -> Tuple[str, Any]:
+    """Fetch the status (SUCCESS/FAILURE/UNKNOWN) and timestamp for a given build."""
+    logger.info(f"Fetching status for build {latest_build_id}")
+    finished_file = f"{prefix}{latest_build_id}/finished.json"
+    url = f"{BASE_URL}/{urllib.parse.quote_plus(finished_file)}"
+    data = make_request(url, params={"alt": "media"})
+    status = data.get("result", "UNKNOWN")
+    timestamp = data.get("timestamp", None)
+    return status, timestamp
+
+# --- Domain Model ---
+
+@dataclass
+class TestResults:
+    """Represents a single test run result."""
+    ocp_version: str
+    gpu_version: str
+    status: str
+    link: str
+    timestamp: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert TestResults object to a dictionary for JSON serialization."""
+        return {
+            "ocp": self.ocp_version,
+            "gpu": self.gpu_version,
+            "status": self.status,
+            "link": self.link,
+            "timestamp": self.timestamp,
+        }
+
+# --- Core Functions ---
+
+def get_job_results(
+    pr_id: str,
+    prefix: str,
+    ocp_version: str,
+    gpu_version_suffix: str,
+    ocp_data: Dict[str, List[Dict[str, Any]]]
+) -> None:
+    """Fetch and store results for a specific job prefix."""
+    logger.info(f"Processing job results for {prefix}")
+    params = {
+        "prefix": prefix,
+        "alt": "json",
+        "delimiter": "/",
+        "includeFoldersAsPrefixes": "True",
+        "maxResults": "1000",
+        "projection": "noAcl",
+    }
+    headers = {"Accept": "application/json"}
+    response_data = make_request(BASE_URL, params=params, headers=headers)
+    latest_build = fetch_file_content(response_data["items"][0]["name"])
+    logger.info(f"Latest build for {prefix}: {latest_build}")
+
+    status, timestamp = get_status_and_time(prefix, latest_build)
+    job_url = get_job_url(pr_id, ocp_version, gpu_version_suffix, latest_build)
+
+    if status == "SUCCESS":
+        exact_ocp, exact_gpu_version = get_versions(prefix, latest_build, gpu_version_suffix)
+        result = TestResults(exact_ocp, exact_gpu_version, status, job_url, timestamp)
+    else:
+        converted_gpu = gpu_suffix_to_version(gpu_version_suffix)
+        result = TestResults(ocp_version, converted_gpu, status, job_url, timestamp)
+    ocp_data.setdefault(ocp_version, []).append(result.to_dict())
+
+def get_all_pr_tests(pr_num: str, ocp_data: Dict[str, List[Dict[str, Any]]]) -> None:
+    """Retrieve and store test results for all jobs under a single PR."""
+    logger.info(f"Fetching tests for PR #{pr_num}")
+    params = {
+        "prefix": f"pr-logs/pull/rh-ecosystem-edge_nvidia-ci/{pr_num}/",
+        "alt": "json",
+        "delimiter": "/",
+        "includeFoldersAsPrefixes": "True",
+        "maxResults": "1000",
+        "projection": "noAcl",
+    }
+    headers = {"Accept": "application/json"}
+    response_data = make_request(BASE_URL, params=params, headers=headers)
+    prefixes = response_data.get("prefixes", [])
+
+    for job in prefixes:
+        match = TEST_PATTERN.match(job)
+        if not match:
+            continue
+        ocp = match.group("ocp_version")
+        gpu_suffix = match.group("gpu_version")
+        get_job_results(pr_num, job, ocp, gpu_suffix, ocp_data)
+    
+def retrieve_all_prs(ocp_data: Dict[str, List[Dict[str, Any]]]) -> None:
+    """Retrieve and store test results for all closed PRs against the main branch."""
+    logger.info("Retrieving PR history...")
+    url = "https://api.github.com/repos/rh-ecosystem-edge/nvidia-ci/pulls"
+    params = {"state": "closed", "base": "main", "per_page": "100", "page": "1"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28"
+    }
+    response_data = make_request(url, params=params, headers=headers)
+    for pr in response_data:
+        pr_num = str(pr["number"])
+        logger.info(f"Processing PR #{pr_num}")
+        get_all_pr_tests(pr_num, ocp_data)
+   
+def save_to_json(new_data: Dict[str, List[Dict[str, Any]]],
+                 output_dir: str,
+                 new_data_file: str,
+                 existing_data: Dict[str, List[Dict[str, Any]]] = None) -> None:
+    """
+    Merge new_data into existing_data (if provided) and write to JSON.
+    This ensures old entries remain and new ones are appended.
+    """
+    file_path = os.path.join(output_dir, new_data_file)
+    logger.info(f"Saving JSON to {file_path}")
+    merged_data = existing_data.copy() if existing_data else {}
+    for key, new_values in new_data.items():
+        merged_data.setdefault(key, []).extend(new_values)
+    with open(file_path, "w") as f:
+        json.dump(merged_data, f, indent=4)
+    logger.info(f"Data successfully saved to {file_path}")
+
+# --- Main Function ---
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate test matrix data")
+    parser.add_argument("--pr", default="all", help="PR number to process; use 'all' for full history")
+    parser.add_argument("--output_dir", required=True, help="Directory to store the output JSON")
+    parser.add_argument("--old_data_file", required=True, help="Name of the existing json file")
+    parser.add_argument("--new_data_file", required=True, help="Name of the generated json file")
+    args = parser.parse_args()
+
+    # Combine the output_dir with the old_data_file name
+    old_data_path = os.path.join(args.output_dir, args.old_data_file)
+    with open(old_data_path, "r") as f:
+        old_data: Dict[str, List[Dict[str, Any]]] = json.load(f)
+    logger.info(f"Loaded old data from: {old_data_path} with keys: {list(old_data.keys())}")
+
+    # local_ocp_data will hold ONLY new data collected during this run.
+    local_ocp_data: Dict[str, List[Dict[str, Any]]] = {}
+
+    if args.pr.lower() == "all":
+        retrieve_all_prs(local_ocp_data)
+    else:
+        get_all_pr_tests(args.pr, local_ocp_data)
+
+    # Merge old data with new data and save
+    save_to_json(local_ocp_data, args.output_dir, args.new_data_file, existing_data=old_data)
+
+if __name__ == "__main__":
+    main()

--- a/workflows/test_matrix_dashboard/generate_test_matrix_ui.py
+++ b/workflows/test_matrix_dashboard/generate_test_matrix_ui.py
@@ -1,0 +1,283 @@
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+from logger import logger
+
+
+
+def generate_html_header() -> str:
+    return """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Test Matrix: NVIDIA GPU Operator on Red Hat OpenShift</title>
+        <style>
+            body {
+                font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+                background-color: #f1f1f1;
+                margin: 0;
+                padding: 20px;
+                color: #333;
+            }
+            h2 {
+                text-align: center;
+                margin-bottom: 20px;
+                color: #007bff;
+                font-size: 28px;
+            }
+            .ocp-version-container {
+                margin-bottom: 40px;
+                padding: 20px;
+                background-color: #ffffff;
+                border-radius: 8px;
+                box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            }
+            .ocp-version-header {
+                font-size: 26px;
+                margin-bottom: 15px;
+                color: #333;
+                background-color: #f7f9fc;
+                padding: 15px;
+                border-radius: 8px;
+                font-weight: bold;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 20px 0;
+                background-color: #ffffff;
+                box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+                border-radius: 8px;
+            }
+            th, td {
+                border: 1px solid #ddd;
+                padding: 12px;
+                text-align: left;
+                font-size: 14px;
+                transition: background-color 0.2s ease;
+            }
+            th {
+                background-color: #007BFF;
+                color: white;
+                cursor: pointer;
+                font-size: 16px;
+                position: relative;
+            }
+            th:hover {
+                background-color: #0056b3;
+            }
+            th:after {
+                content: ' ▼';
+                position: absolute;
+                right: 10px;
+                font-size: 12px;
+                color: white;
+            }
+            th.asc:after {
+                content: ' ▲';
+            }
+            th.desc:after {
+                content: ' ▼';
+            }
+            td {
+                background-color: #f9f9f9;
+            }
+            td:hover {
+                background-color: #f1f1f1;
+                cursor: pointer;
+            }
+            .history-bar {
+                display: flex;
+                align-items: center;
+                gap: 20px;
+                margin: 20px 0;
+                padding: 12px 18px;
+                border: 2px solid #007BFF;
+                border-radius: 8px;
+                background-color: #ffffff;
+                color: #333;
+                box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+                transition: background-color 0.2s ease;
+                flex-wrap: wrap;
+            }
+            .history-square {
+                width: 55px;
+                height: 55px;
+                border-radius: 8px;
+                cursor: pointer;
+                transition: transform 0.1s ease;
+                border: 2px solid #ddd;
+                position: relative;
+                overflow: hidden;
+                box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+            }
+            .history-square:hover {
+                transform: scale(1.2);
+                box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
+            }
+            .history-success {
+                background-color: #64dd17;
+            }
+            .history-failure {
+                background-color: #ff3d00;
+            }
+            .history-aborted {
+                background-color: #ffd600;
+            }
+            .history-square:hover::after {
+                content: attr(title);
+                position: absolute;
+                background-color: #333;
+                color: white;
+                padding: 8px 12px;
+                border-radius: 5px;
+                font-size: 12px;
+                top: 60px;
+                z-index: 10;
+                width: 200px;
+                text-align: center;
+            }
+            @media screen and (max-width: 768px) {
+                table {
+                    font-size: 14px;
+                }
+                .history-bar {
+                    flex-wrap: wrap;
+                    justify-content: center;
+                }
+                .history-square {
+                    width: 45px;
+                    height: 45px;
+                }
+            }
+        </style>
+    </head>
+    <body>
+    <h2>Test Matrix: NVIDIA GPU Operator on Red Hat OpenShift</h2>
+    <script>
+        function sortTable(column, tableId) {
+            var table = document.getElementById(tableId);
+            var rows = Array.from(table.rows);
+            var isAscending = table.rows[0].cells[column].classList.contains('asc');
+            rows = rows.slice(1);
+            rows.sort(function(rowA, rowB) {
+                var cellA = rowA.cells[column].innerText;
+                var cellB = rowB.cells[column].innerText;
+                if (!isNaN(cellA) && !isNaN(cellB)) {
+                    return isAscending ? cellA - cellB : cellB - cellA;
+                } else {
+                    return isAscending ? cellA.localeCompare(cellB) : cellB.localeCompare(cellA);
+                }
+            });
+            rows.forEach(function(row) {
+                table.appendChild(row);
+            });
+            var header = table.rows[0].cells[column];
+            header.classList.toggle('asc', !isAscending);
+            header.classList.toggle('desc', isAscending);
+        }
+    </script>
+    """
+
+def generate_regular_results_table(ocp_version: str, regular_results: List[Dict[str, Any]], bundle_results: List[Dict[str, Any]]) -> str:
+    table_html = f"""
+    <div class="ocp-version-container">
+        <div class="ocp-version-header">OpenShift {ocp_version}</div>
+        <div><strong>Operator Catalog</strong></div>
+        <table id="table-{ocp_version}-regular">
+            <thead>
+                <tr>
+                    <th onclick="sortTable(0, 'table-{ocp_version}-regular')">Full OCP Version</th>
+                    <th onclick="sortTable(1, 'table-{ocp_version}-regular')">GPU Version</th>
+                    <th>Prow Job</th>
+                </tr>
+            </thead>
+            <tbody>
+    """
+    for result in regular_results:
+        full_ocp = result["ocp"]
+        gpu_version = result["gpu"]
+        link = result["link"]
+        table_html += f"""
+        <tr>
+            <td>{full_ocp}</td>
+            <td>{gpu_version}</td>
+            <td><a href="{link}" target="_blank">Job Link</a></td>
+        </tr>
+        """
+    table_html += """
+            </tbody>
+        </table>
+    """
+    if bundle_results:
+        table_html += """
+        <div><strong>Bundles Associated with this Regular Results</strong></div>
+        <div style="padding-left: 20px; display: flex; flex-wrap: wrap; gap: 15px;">
+        """
+        for bundle in bundle_results:
+            status = bundle.get("status", "Unknown")
+            status_class = "history-success" if status == "SUCCESS" else "history-failure" if status == "FAILURE" else "history-aborted"
+            bundle_timestamp = datetime.fromtimestamp(bundle["timestamp"], timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            table_html += f"""
+            <div class='history-square {status_class}' 
+                onclick='window.open("{bundle["link"]}", "_blank")' 
+                title='Status: {status} | Timestamp: {bundle_timestamp}'>
+            </div>
+            """
+        table_html += "</div>"
+        last_bundle_date = datetime.fromtimestamp(bundle_results[0]["timestamp"], timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        table_html += f"""
+        <div><strong>Last Bundle Job Date: </strong>{last_bundle_date}</div>
+        """
+    table_html += "</div>"
+    return table_html
+
+def generate_test_matrix(ocp_data: Dict[str, List[Dict[str, Any]]]) -> str:
+    sorted_ocp_versions = sorted(ocp_data.keys(), reverse=True)
+    html_content = generate_html_header()
+    for ocp_version in sorted_ocp_versions:
+        results = ocp_data[ocp_version]
+        regular_results = [
+            r for r in results
+            if ("bundle" not in r["gpu"].lower())
+               and ("master" not in r["gpu"].lower())
+               and (r.get("status") == "SUCCESS")
+        ]
+        bundle_results = [r for r in results if r not in regular_results]
+        html_content += generate_regular_results_table(ocp_version, regular_results, bundle_results)
+    html_content += """
+    </body>
+    </html>
+    """
+    return html_content
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate test matrix HTML UI")
+    parser.add_argument("--output_dir", required=True, help="Output directory where JSON is stored and HTML will be generated")
+    parser.add_argument("--data_file", required=True, help="Name of the json file")
+    parser.add_argument("--output_file", required=True, help="Name of the generated html file")
+    args = parser.parse_args()
+
+    # Construct path to JSON file in the output directory
+    json_path = os.path.join(args.output_dir, args.data_file)
+
+    with open(json_path, "r") as f:
+        ocp_data = json.load(f)
+    logger.info(f"Loaded JSON data with keys: {list(ocp_data.keys())} from {json_path}")
+
+    html_content = generate_test_matrix(ocp_data)
+
+    # Save the HTML in the same output directory
+    output_path = os.path.join(args.output_dir, args.output_file)
+    with open(output_path, "w") as f:
+        f.write(html_content)
+    logger.info(f"Matrix report generated: {output_path}")
+
+if __name__ == "__main__":
+    main()

--- a/workflows/test_matrix_dashboard/logger.py
+++ b/workflows/test_matrix_dashboard/logger.py
@@ -1,0 +1,12 @@
+
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,  # Log all levels from DEBUG and above
+    format="%(asctime)s [%(levelname)s] %(filename)s:%(lineno)d - %(message)s",  # Include time, level, filename, and line number
+    handlers=[
+        logging.StreamHandler(),  # Outputs to terminal
+    ]
+)
+
+logger = logging.getLogger(__name__)

--- a/workflows/test_matrix_dashboard/requirements.txt
+++ b/workflows/test_matrix_dashboard/requirements.txt
@@ -1,0 +1,5 @@
+requests==2.32.3
+requests-file==2.0.0
+requests-ftp==0.3.1
+requests-oauthlib==2.0.0
+requests-toolbelt==1.0.0


### PR DESCRIPTION
Add matrix generation dashboard from PR events

This commit introduces:
- A Python-based workflow that updates `ocp_data.json` when new PRs are opened.
- A UI script (`generate_test_matrix_ui.py`) to produce an HTML dashboard from `ocp_data.json`.
- GitHub Actions workflow logic to automatically fetch test data, update the JSON, generate an HTML

Overall, this provides a dynamic matrix showing test statuses for the NVIDIA GPU Operator on different OpenShift versions, updated automatically whenever relevant pull requests occur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Launched an interactive test matrix dashboard that visually displays test results with clear status indicators and sorting capabilities.
  - Automated processes now generate and deploy the dashboard, ensuring timely, updated views.

- **Documentation**
  - Added a comprehensive guide detailing setup, local testing, and deployment steps to help users get started with the new dashboard feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->