### PR TITLE
Added support for end-to-end RDMA testcase for NNO

### DIFF
--- a/internal/nvidianetworkconfig/config.go
+++ b/internal/nvidianetworkconfig/config.go
@@ -13,6 +13,16 @@ type NvidiaNetworkConfig struct {
 	CleanupAfterTest                   bool   `envconfig:"NVIDIANETWORK_CLEANUP" default:"true"`
 	DeployFromBundle                   bool   `envconfig:"NVIDIANETWORK_DEPLOY_FROM_BUNDLE" default:"false"`
 	BundleImage                        string `envconfig:"NVIDIANETWORK_BUNDLE_IMAGE"`
+	OfedDriverVersion                  string `envconfig:"NVIDIANETWORK_OFED_DRIVER_VERSION"`
+	OfedDriverRepository               string `envconfig:"NVIDIANETWORK_OFED_REPOSITORY"`
+	RdmaClientHostname                 string `envconfig:"NVIDIANETWORK_RDMA_CLIENT_HOSTNAME"`
+	RdmaServerHostname                 string `envconfig:"NVIDIANETWORK_RDMA_SERVER_HOSTNAME"`
+	RdmaTestImage                      string `envconfig:"NVIDIANETWORK_RDMA_TEST_IMAGE"`
+	MellanoxEthernetInterfaceName      string `envconfig:"NVIDIANETWORK_MELLANOX_ETH_INTERFACE_NAME"`
+	MellanoxInfinibandInterfaceName    string `envconfig:"NVIDIANETWORK_MELLANOX_IB_INTERFACE_NAME"`
+	MacvlanNetworkName                 string `envconfig:"NVIDIANETWORK_MACVLANNETWORK_NAME"`
+	MacvlanNetworkIPAMRange            string `envconfig:"NVIDIANETWORK_MACVLANNETWORK_IPAM_RANGE"`
+	MacvlanNetworkIPAMGateway          string `envconfig:"NVIDIANETWORK_MACVLANNETWORK_IPAM_GATEWAY"`
 	OperatorUpgradeToChannel           string `envconfig:"NVIDIANETWORK_SUBSCRIPTION_UPGRADE_TO_CHANNEL"`
 	NNOFallbackCatalogsourceIndexImage string `envconfig:"NVIDIANETWORK_NNO_FALLBACK_CATALOGSOURCE_INDEX_IMAGE"`
 	NFDFallbackCatalogsourceIndexImage string `envconfig:"NVIDIANETWORK_NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE"`


### PR DESCRIPTION
Added support to run RDMA ib_write_bw connectivity tests (Shared Device Ethernet) after deploying NNO Operator, NicCLusterPolicy, MacvlanNetwork CRs.

In order to run just the RDMA testcase on a cluster with NNO deployed, use the env variable TEST_LABELS="rdma".  If you want to fully Deploy NFD, NNO, NicClusterPolicy (with updates) and MacvlanNetwork CRs, set TEST_LABELS="nno,rdma", along with other needed env variables as described in the updated README.md file.

Modified the following files:

- README.md
- internal/nvidianetworkconfig/config.go
- internal/rdma/rdma-test.go
- tests/nvidianetwork/deploy-nno-test.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the configuration guide with new environment variables for RDMA, Mellanox interfaces, and Macvlan options.
  - Revised sample commands to include additional test labels and updated version information.

- **New Features**
  - Expanded network configuration capabilities for enhanced RDMA and overall network operator functionality.
  - Added new test cases for RDMA connectivity.

- **Tests**
  - Improved test coverage with added RDMA connectivity scenarios and refined default settings for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->