### PR TITLE
Added support to create IPoIBNetwork Custom CR and infiniband RDMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ NVIDIA Network Operator-specific (NNO) parameters for the script are controlled 
 - `NVIDIANETWORK_RDMA_MLX_DEVICE:` mlx5 device ID corresponding to the interface port connected to Spectrum or Infiniband switch - _required_
 - `NVIDIANETWORK_RDMA_CLIENT_HOSTNAME:` RDMA Client hostname of first worker node for ib_write_bw test - _required when running the RDMA testcase_ 
 - `NVIDIANETWORK_RDMA_SERVER_HOSTNAME:` RDMA Server hostname of second worker node for ib_write_bw test - _required when running the RDMA testcase_   
-- `NVIDIANETWORK_RDMA_TEST_IMAGE:` RDMA Test Container Image that runs the entrypoint.sh script with optional arguments specified in the pod spec.  This container will clone the "https://github.com/linux-rdma/perftest" repo and builds the ib_write_bw binaries with or without cuda headers.  It will also run the ib_write_bw command with arguments either in CLient or Server mode.  Defaults to "quay.io/wabouham/ecosys-nvidia/rdma-tools:0.0.1" - _optional_
+- `NVIDIANETWORK_RDMA_TEST_IMAGE:` RDMA Test Container Image that runs the entrypoint.sh script with optional arguments specified in the pod spec.  This container will clone the "https://github.com/linux-rdma/perftest" repo and builds the ib_write_bw binaries with or without cuda headers.  It will also run the ib_write_bw command with arguments either in CLient or Server mode.  Defaults to "quay.io/wabouham/ecosys-nvidia/rdma-tools:0.0.2" - _optional_
 - `NVIDIANETWORK_MELLANOX_ETH_INTERFACE_NAME`: Mellanox Ethernet Interface Name - Defaults to "ens8f0np0" if not specified - _optional_  
 - `NVIDIANETWORK_MELLANOX_IB_INTERFACE_NAME`:  Mellanox Infiniband Interface Name - Defaults to "ens8f0np0" if not specified - _optional_   
-- `NVIDIANETWORK_MACVLANNETWORK_NAME`: MacvlanNetwork Custom Resource instance name  - Defaults to name from Cluster Service Bersion alm-examples section if not specified  - _optional_ 
+- `NVIDIANETWORK_MACVLANNETWORK_NAME`: MacvlanNetwork Custom Resource instance name  - Defaults to name from Cluster Service Version alm-examples section if not specified  - _optional_ 
 - `NVIDIANETWORK_MACVLANNETWORK_IPAM_RANGE`: MacvlanNetwork Custom Resource instance IPAM or IP Address/Subnet mask range for Eth or IB interface - _required_    
-- `NVIDIANETWORK_MACVLANNETWORK_IPAM_GATEWAY`: MacvlanNetwork Custom Resource instance IPAM Default Gateway for specified ip address range - _required_         
-
+- `NVIDIANETWORK_MACVLANNETWORK_IPAM_GATEWAY`: MacvlanNetwork Custom Resource instance IPAM Default Gateway for specified ip address range - _required_
+- `NVIDIANETWORK_IPOIBNETWORK_NAME`: IPoIBNetwork Custom Resource instance name  - Defaults to name from Cluster Service Version alm-examples section if not specified  - _optional_
+- `NVIDIANETWORK_IPOIBNETWORK_IPAM_RANGE`: IPoIBNetwork Custom Resource instance IPAM or IP Address/Subnet mask range for Eth or IB interface - _required_
+- `export NVIDIANETWORK_IPOIBNETWORK_IPAM_EXCLUDEIP1`: IPoIBNetwork Custom Resource instance IPAM first IP Address and Mask excluded from range - _required_
+- `export NVIDIANETWORK_IPOIBNETWORK_IPAM_EXCLUDEIP2`: IPoIBNetwork Custom Resource instance IPAM second IP Address and Mask excluded from range - _required_
 
 It is recommended to execute the runner script through the `make run-tests` make target.
 
@@ -169,7 +172,7 @@ $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
 $ export REPORTS_DUMP_DIR=/tmp/nvidia-nno-ci-logs-dir
 $ export TEST_FEATURES="nvidianetwork"
-$ export TEST_LABELS='nno,rdma'
+$ export TEST_LABELS='nno,rdma-shared-dev'
 $ export TEST_TRACE=true
 $ export VERBOSE_LEVEL=100
 $ export NVIDIANETWORK_CATALOGSOURCE="certified-operators"
@@ -186,14 +189,23 @@ $ export NVIDIANETWORK_DEPLOY_FROM_BUNDLE=true
 $ export NVIDIANETWORK_BUNDLE_IMAGE="nvcr.io/.../network-operator-bundle:v25.1.0-rc.2"
 $ export NVIDIANETWORK_MELLANOX_ETH_INTERFACE_NAME="ens8f0np0"
 $ export NVIDIANETWORK_MELLANOX_IB_INTERFACE_NAME="ibs2f0"
-$ export NVIDIANETWORK_MACVLANNETWORK_NAME="rdmashared-net"
 $ export NVIDIANETWORK_RDMA_WORKLOAD_NAMESPACE="default"
+# RDMA Shared Device Test Link Type: Infiniband or Ethernet
+$ export NVIDIANETWORK_RDMA_LINK_TYPE="infiniband"
+# For RDMA Shared Device Ethernet:
+$ export NVIDIANETWORK_MACVLANNETWORK_NAME="rdmashared-net"
 $ export NVIDIANETWORK_RDMA_LINK_TYPE="ethernet"
 $ export NVIDIANETWORK_RDMA_MLX_DEVICE="mlx5_2"
+# For RDMA Shared Device Infiniband:
+$ export NVIDIANETWORK_RDMA_MLX_DEVICE="mlx5_3"
+$ export NVIDIANETWORK_IPOIBNETWORK_NAME="example-ipoibnetwork"
+$ export NVIDIANETWORK_IPOIBNETWORK_IPAM_RANGE=192.168.6.225/24
+$ export NVIDIANETWORK_IPOIBNETWORK_IPAM_EXCLUDEIP1=192.168.6.229/30
+$ export NVIDIANETWORK_IPOIBNETWORK_IPAM_EXCLUDEIP2=192.168.6.236/32
 
 
 $ make run-tests
 Executing nvidiagpu test-runner script
 scripts/test-runner.sh
-ginkgo -timeout=24h --keep-going --require-suite -r -vv --trace --label-filter="nno,rdma" ./tests/nvidianetwork
+ginkgo -timeout=24h --keep-going --require-suite -r -vv --trace --label-filter="nno,rdma-shared-dev" ./tests/nvidianetwork
 ```

--- a/internal/nvidianetworkconfig/config.go
+++ b/internal/nvidianetworkconfig/config.go
@@ -26,6 +26,10 @@ type NvidiaNetworkConfig struct {
 	MacvlanNetworkName                 string `envconfig:"NVIDIANETWORK_MACVLANNETWORK_NAME"`
 	MacvlanNetworkIPAMRange            string `envconfig:"NVIDIANETWORK_MACVLANNETWORK_IPAM_RANGE"`
 	MacvlanNetworkIPAMGateway          string `envconfig:"NVIDIANETWORK_MACVLANNETWORK_IPAM_GATEWAY"`
+	IPoIBNetworkName                   string `envconfig:"NVIDIANETWORK_IPOIBNETWORK_NAME"`
+	IPoIBNetworkIPAMRange              string `envconfig:"NVIDIANETWORK_IPOIBNETWORK_IPAM_RANGE"`
+	IPoIBNetworkIPAMExcludeIP1         string `envconfig:"NVIDIANETWORK_IPOIBNETWORK_IPAM_EXCLUDEIP1"`
+	IPoIBNetworkIPAMExcludeIP2         string `envconfig:"NVIDIANETWORK_IPOIBNETWORK_IPAM_EXCLUDEIP2"`
 	OperatorUpgradeToChannel           string `envconfig:"NVIDIANETWORK_SUBSCRIPTION_UPGRADE_TO_CHANNEL"`
 	NNOFallbackCatalogsourceIndexImage string `envconfig:"NVIDIANETWORK_NNO_FALLBACK_CATALOGSOURCE_INDEX_IMAGE"`
 	NFDFallbackCatalogsourceIndexImage string `envconfig:"NVIDIANETWORK_NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE"`

--- a/internal/wait/networkwait.go
+++ b/internal/wait/networkwait.go
@@ -55,3 +55,24 @@ func MacvlanNetworkReady(apiClient *clients.Settings, macvlanNetworkName string,
 			return macVlanNetwork.Object.Status.State == networkoperator.StateReady, nil
 		})
 }
+
+// IPoIBNetworkReady Waits until ipoibNetwork is Ready.
+func IPoIBNetworkReady(apiClient *clients.Settings, ipoibNetworkName string, pollInterval,
+	timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(
+		context.Background(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+			ipoIBNetwork, err := nvidianetwork.PullIPoIBNetwork(apiClient, ipoibNetworkName)
+
+			if err != nil {
+				glog.V(networkparams.LogLevel).Infof("IPoIBNetwork pull from cluster error: %s\n", err)
+
+				return false, err
+			}
+
+			glog.V(networkparams.LogLevel).Infof("IPoIBNetwork %s in now in %s state",
+				ipoIBNetwork.Object.Name, ipoIBNetwork.Object.Status.State)
+
+			// returns true, nil when IPoIBNetwork is ready, this exits out of the PollUntilContextTimeout()
+			return ipoIBNetwork.Object.Status.State == networkoperator.StateReady, nil
+		})
+}

--- a/pkg/nvidianetwork/ipoibnetwork.go
+++ b/pkg/nvidianetwork/ipoibnetwork.go
@@ -1,0 +1,282 @@
+package nvidianetwork
+
+import (
+	"context"
+	"fmt"
+	nvidianetworkv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
+
+	"github.com/golang/glog"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/msg"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IPoIBNetworkBuilder  provides a struct for IPoIBNetwork object
+// from the cluster and a IPoIBNetwork definition.
+type IPoIBNetworkBuilder struct {
+	// IPoIBNetworkBuilder  definition. Used to create
+	// IPoIBNetworkBuilder  object with minimum set of required elements.
+	Definition *nvidianetworkv1alpha1.IPoIBNetwork
+	// Created IPoIBNetworkBuilder  object on the cluster.
+	Object *nvidianetworkv1alpha1.IPoIBNetwork
+	// api client to interact with the cluster.
+	apiClient *clients.Settings
+	// errorMsg is processed before IPoIBNetworkBuilder  object is created.
+	errorMsg string
+}
+
+// NewIPoIBNetworkBuilderFromObjectString creates a IPoIBNetworkBuilder  object from CSV alm-examples.
+func NewIPoIBNetworkBuilderFromObjectString(apiClient *clients.Settings, almExample string) *IPoIBNetworkBuilder {
+	glog.V(100).Infof(
+		"Initializing new IPoIBNetworkBuilder  structure from almExample string")
+
+	IPoIBNetwork, err := getIPoIBNetworkFromAlmExample(almExample)
+
+	if err != nil {
+		glog.V(100).Infof(
+			"Error initializing IPoIBNetwork from alm-examples: %s", err.Error())
+
+		builder := IPoIBNetworkBuilder{
+			apiClient: apiClient,
+			errorMsg:  fmt.Sprintf("Error initializing IPoIBNetwork from alm-examples: %s", err.Error()),
+		}
+
+		return &builder
+	}
+
+	if IPoIBNetwork == nil {
+		builder := IPoIBNetworkBuilder{
+			apiClient: apiClient,
+			errorMsg:  "IPoIBNetwork is nil after parsing almExample",
+		}
+		return &builder
+	}
+
+	glog.V(100).Infof(
+		"Initializing new IPoIBNetworkBuilder  structure from almExample string with IPoIBNetwork name: %s",
+		IPoIBNetwork.Name)
+
+	builder := IPoIBNetworkBuilder{
+		apiClient:  apiClient,
+		Definition: IPoIBNetwork,
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The IPoIBNetwork object definition is nil")
+
+		builder.errorMsg = "IPoIBNetwork 'Object.Definition' is nil"
+	}
+
+	return &builder
+}
+
+// Get returns IPoIBNetwork object if found.
+func (builder *IPoIBNetworkBuilder) Get() (*nvidianetworkv1alpha1.IPoIBNetwork, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof(
+		"Collecting IPoIBNetwork object %s", builder.Definition.Name)
+
+	IPoIBNetwork := &nvidianetworkv1alpha1.IPoIBNetwork{}
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
+		Name: builder.Definition.Name,
+	}, IPoIBNetwork)
+
+	if err != nil {
+		glog.V(100).Infof(
+			"IPoIBNetwork object %s doesn't exist", builder.Definition.Name)
+
+		return nil, err
+	}
+
+	return IPoIBNetwork, err
+}
+
+// PullIPoIBNetwork loads an existing IPoIBNetwork into IPoIBNetworkBuilder  struct.
+func PullIPoIBNetwork(apiClient *clients.Settings, name string) (*IPoIBNetworkBuilder, error) {
+	glog.V(100).Infof("Pulling existing IPoIBNetwork name: %s", name)
+
+	builder := IPoIBNetworkBuilder{
+		apiClient: apiClient,
+		Definition: &nvidianetworkv1alpha1.IPoIBNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("IPoIBNetwork name is empty")
+
+		builder.errorMsg = "IPoIBNetwork 'name' cannot be empty"
+		return nil, fmt.Errorf(builder.errorMsg)
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("IPoIBNetwork object %s doesn't exist", name)
+	}
+
+	builder.Definition = builder.Object
+
+	return &builder, nil
+}
+
+// Exists checks whether the given IPoIBNetwork exists.
+func (builder *IPoIBNetworkBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof(
+		"Checking if IPoIBNetwork %s exists", builder.Definition.Name)
+
+	var err error
+	builder.Object, err = builder.Get()
+
+	if err != nil {
+		glog.V(100).Infof("Failed to collect IPoIBNetwork object due to %s", err.Error())
+	}
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Delete removes a IPoIBNetwork.
+func (builder *IPoIBNetworkBuilder) Delete() (*IPoIBNetworkBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Deleting IPoIBNetwork %s", builder.Definition.Name)
+
+	if !builder.Exists() {
+		return builder, fmt.Errorf("IPoIBNetwork cannot be deleted because it does not exist")
+	}
+
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
+
+	if err != nil {
+		return builder, fmt.Errorf("cannot delete IPoIBNetwork: %w", err)
+	}
+
+	builder.Object = nil
+
+	return builder, nil
+}
+
+// Create makes a IPoIBNetwork in the cluster and stores the created object in struct.
+func (builder *IPoIBNetworkBuilder) Create() (*IPoIBNetworkBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Creating the IPoIBNetwork %s", builder.Definition.Name)
+
+	var err error
+	if !builder.Exists() {
+		err = builder.apiClient.Create(context.TODO(), builder.Definition)
+
+		if err == nil {
+			builder.Object = builder.Definition
+		} else {
+			glog.V(100).Infof("Error creating the IPoIBNetwork '%s' : '%s'",
+				builder.Definition.Name, err.Error())
+		}
+	}
+
+	return builder, err
+}
+
+// Update renovates the existing IPoIBNetwork object with the definition in builder.
+func (builder *IPoIBNetworkBuilder) Update(force bool) (*IPoIBNetworkBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Updating the IPoIBNetwork object named:  %s", builder.Definition.Name)
+
+	err := builder.apiClient.Update(context.TODO(), builder.Definition)
+
+	if err != nil {
+		if force {
+			glog.V(100).Infof(msg.FailToUpdateNotification("IPoIBNetwork", builder.Definition.Name))
+
+			builder, err := builder.Delete()
+
+			if err != nil {
+				glog.V(100).Infof(
+					msg.FailToUpdateError("IPoIBNetwork", builder.Definition.Name))
+
+				return nil, err
+			}
+
+			return builder.Create()
+		}
+	}
+
+	return builder, err
+}
+
+// getIPoIBNetworkFromAlmExample extracts the IPoIBNetwork from the alm-examples block.
+func getIPoIBNetworkFromAlmExample(almExample string) (*nvidianetworkv1alpha1.IPoIBNetwork, error) {
+	IPoIBNetworkList := &nvidianetworkv1alpha1.IPoIBNetworkList{}
+
+	if almExample == "" {
+		return nil, fmt.Errorf("almExample is an empty string")
+	}
+
+	err := json.Unmarshal([]byte(almExample), &IPoIBNetworkList.Items)
+
+	if err != nil {
+		glog.V(100).Infof("Error unmarshalling IPoIBNetwork from almExamples: '%s'", err.Error())
+
+		return nil, err
+	}
+
+	if len(IPoIBNetworkList.Items) == 0 {
+		return nil, fmt.Errorf("failed to get alm examples")
+	}
+
+	for i := range IPoIBNetworkList.Items {
+		if IPoIBNetworkList.Items[i].Kind == "IPoIBNetwork" {
+			return &IPoIBNetworkList.Items[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("IPoIBNetwork not found in alm examples")
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *IPoIBNetworkBuilder) validate() (bool, error) {
+	resourceCRD := nvidianetworkv1alpha1.IPoIBNetworkCRDName
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
Added support to run RDMA Shared Device Infiniband Test Case.

Updated files:
- README.md
- internal/nvidianetworkconfig/config.go
- internal/wait/networkwait.go
- tests/nvidianetwork/deploy-nno-test.go

Added file:
- pkg/nvidianetwork/ipoibnetwork.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating, updating, and managing IPoIBNetwork resources for InfiniBand network configurations.
  - Enhanced test suite to deploy and validate IPoIBNetwork resources alongside existing network types.

- **Documentation**
  - Updated instructions and examples to include new environment variables and configuration steps for IPoIBNetwork.
  - Corrected minor typos and clarified usage for RDMA shared device tests with both Ethernet and InfiniBand.

- **Bug Fixes**
  - Fixed a typo in the MacvlanNetwork Custom Resource documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->