### PR TITLE
Running the must gather script after successful run

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,17 +89,28 @@ func (cfg *GeneralConfig) WriteReport(fileName string, content []byte) error {
 // GetDumpFailedTestReportLocation returns destination file for failed tests logs.
 func (cfg *GeneralConfig) GetDumpFailedTestReportLocation(file string) string {
 	if cfg.DumpFailedTests {
-		if _, err := os.Stat(cfg.ReportsDirAbsPath); os.IsNotExist(err) {
-			log.Printf("Path to report dir %s does not exist, trying to create now", cfg.ReportsDirAbsPath)
-			err := os.MkdirAll(cfg.ReportsDirAbsPath, 0744)
-			if err != nil {
-				log.Fatalf("panic: Failed to create report dir due to %s", err)
-			}
-		}
-		dumpFileName := strings.TrimSuffix(filepath.Base(file), filepath.Ext(filepath.Base(file)))
-		return filepath.Join(cfg.ReportsDirAbsPath, fmt.Sprintf("failed_%s", dumpFileName))
+		return cfg.getDumpReportLocation(file, "failed_")
 	}
 	return ""
+}
+
+// GetDumpTestReportLocation returns destination file for test logs regardless of test status.
+func (cfg *GeneralConfig) GetDumpTestReportLocation(file string) string {
+	return cfg.getDumpReportLocation(file, "failed_")
+}
+
+// getDumpReportLocation is a helper function that creates the report directory if needed
+// and returns the destination file path for test logs.
+func (cfg *GeneralConfig) getDumpReportLocation(file string, prefix string) string {
+	if _, err := os.Stat(cfg.ReportsDirAbsPath); os.IsNotExist(err) {
+		log.Printf("Path to report dir %s does not exist, trying to create now", cfg.ReportsDirAbsPath)
+		err := os.MkdirAll(cfg.ReportsDirAbsPath, 0744)
+		if err != nil {
+			log.Fatalf("panic: Failed to create report dir due to %s", err)
+		}
+	}
+	dumpFileName := strings.TrimSuffix(filepath.Base(file), filepath.Ext(filepath.Base(file)))
+	return filepath.Join(cfg.ReportsDirAbsPath, fmt.Sprintf("%s%s", prefix, dumpFileName))
 }
 
 func readFile(cfg *GeneralConfig, cfgFile string) error {

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -134,10 +134,7 @@ func removeFile(fPath string) error {
 	return nil
 }
 
-func MustGatherIfFailed(specReport types.SpecReport, artifactDir string, timeout time.Duration) error {
-	if !types.SpecStateFailureStates.Is(specReport.State) {
-		return nil
-	}
+func RunMustGather(artifactDir string, timeout time.Duration) error {
 	if artifactDir == "" {
 		return fmt.Errorf("artifact directory cannot be empty")
 	}

--- a/tests/nvidiagpu/gpu_suite_test.go
+++ b/tests/nvidiagpu/gpu_suite_test.go
@@ -32,11 +32,11 @@ var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
 		specReport, currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
 
-	dumpDir := inittools.GeneralConfig.GetDumpFailedTestReportLocation(currentFile)
+	dumpDir := inittools.GeneralConfig.GetDumpTestReportLocation(currentFile)
 	if dumpDir != "" {
 		artifactDir := fmt.Sprintf("%s/gpu-must-gather", dumpDir)
-		if err := reporter.MustGatherIfFailed(specReport, artifactDir, 5*time.Minute); err != nil {
-			glog.Errorf("Error running MustGatherIfFailed, %v", err)
+		if err := reporter.RunMustGather(artifactDir, 5*time.Minute); err != nil {
+			glog.Errorf("Error running RunMustGather, %v", err)
 		}
 	}
 })


### PR DESCRIPTION
/cc @empovit 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Test logs are now saved to a new location, regardless of test pass or fail status.
- **Refactor**
  - The must-gather operation now runs unconditionally, not just on test failures.
  - Updated error messages and function usage to reflect these changes.
  - Improved handling and organization of test report file locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->