### PR TITLE
Enable GPU operator jobs on OCP 4.13

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -37,7 +37,7 @@ jobs:
 
         env:
           GH_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OCP_IGNORED_VERSIONS_REGEX: "4.[6-9]|4.1[0-1,3]"
+          OCP_IGNORED_VERSIONS_REGEX: "^4.[0-9]$|^4.1[0-1]$"
           VERSION_FILE_PATH: "workflows/versions.json"
           TEST_TO_TRIGGER_FILE_PATH: "workflows/generated-files/tests_to_trigger.txt"
       - name: Create Pull Request


### PR DESCRIPTION
Although 4.13 isn't supported, it's on the upgrade path from 4.12 EUS to newer versions, therefore we must test the GPU operator on it.

As part of this commit, improve the regex to match the entire version to avoid, for example, 4.10 being a match when the intention was 4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the pattern used to ignore specific OpenShift Container Platform versions, resulting in more precise version matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->