### PR TITLE
Add 4.13 manually from test rehearsals

### DIFF
--- a/gpu_operator_matrix.json
+++ b/gpu_operator_matrix.json
@@ -717,5 +717,21 @@
             "prow_job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/144/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1910570483414208512",
             "job_timestamp": 1744355951
         }
+    ],
+    "4.13": [
+        {
+            "ocp_full_version": "4.13.57",
+            "gpu_operator_version": "24.9.2",
+            "test_status": "SUCCESS",
+            "prow_job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/64387/rehearse-64387-pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-24-9-x/1917230177276923904",
+            "job_timestamp": 1745938277
+        },
+        {
+            "ocp_full_version": "4.13.57",
+            "gpu_operator_version": "25.3.0",
+            "test_status": "SUCCESS",
+            "prow_job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/64387/rehearse-64387-pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-25-3-x/1917230177318866944",
+            "job_timestamp": 1745938279
+        }
     ]
 }


### PR DESCRIPTION
The tests ran as part of a PR to the release repo, so we can mark these versions as tested.
https://github.com/openshift/release/pull/64387