### PR TITLE
Runnuing must gather script after each run

### DIFF
--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -134,10 +134,7 @@ func removeFile(fPath string) error {
 	return nil
 }
 
-func MustGatherIfFailed(specReport types.SpecReport, artifactDir string, timeout time.Duration) error {
-	if !types.SpecStateFailureStates.Is(specReport.State) {
-		return nil
-	}
+func RunMustGather(artifactDir string, timeout time.Duration) error {
 	if artifactDir == "" {
 		return fmt.Errorf("artifact directory cannot be empty")
 	}

--- a/tests/nvidiagpu/gpu_suite_test.go
+++ b/tests/nvidiagpu/gpu_suite_test.go
@@ -1,7 +1,6 @@
 package nvidiagpu
 
 import (
-	"fmt"
 	"github.com/golang/glog"
 	"runtime"
 	"testing"
@@ -31,12 +30,8 @@ var _ = JustAfterEach(func() {
 	specReport := CurrentSpecReport()
 	reporter.ReportIfFailed(
 		specReport, currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
-
-	dumpDir := inittools.GeneralConfig.GetDumpFailedTestReportLocation(currentFile)
-	if dumpDir != "" {
-		artifactDir := fmt.Sprintf("%s/gpu-must-gather", dumpDir)
-		if err := reporter.MustGatherIfFailed(specReport, artifactDir, 5*time.Minute); err != nil {
-			glog.Errorf("Error running MustGatherIfFailed, %v", err)
-		}
+	artifactDir := inittools.GeneralConfig.GetReportPath("gpu-must-gather")
+	if err := reporter.RunMustGather(artifactDir, 5*time.Minute); err != nil {
+		glog.Errorf("Failed to collect must-gather for the GPU operator, %v", err)
 	}
 })


### PR DESCRIPTION
/cc @empovit 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Simplified cleanup logic in GPU test suite for more consistent artifact collection and error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->