### PR TITLE
Allow ignoring a specific version even if its minor it not ignored

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -37,7 +37,7 @@ jobs:
 
         env:
           GH_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OCP_IGNORED_VERSIONS_REGEX: "^4.[0-9]$|^4.1[0-1]$"
+          OCP_IGNORED_VERSIONS_REGEX: "^4.[0-9]$|^4.1[0-1]$|^4.19.0-rc.0$"
           VERSION_FILE_PATH: "workflows/versions.json"
           TEST_TO_TRIGGER_FILE_PATH: "workflows/generated-files/tests_to_trigger.txt"
       - name: Create Pull Request

--- a/workflows/openshift.py
+++ b/workflows/openshift.py
@@ -34,10 +34,14 @@ def fetch_ocp_versions() -> dict:
     logger.debug(f'Received OpenShift versions: {accepted_versions}')
 
     for ver in accepted_versions:
+        if ignored_regex.fullmatch(ver):
+            logger.debug(f'Exact version {ver} is ignored')
+            continue
+
         sem_ver = semver.VersionInfo.parse(ver)
         minor = f'{sem_ver.major}.{sem_ver.minor}'
         if ignored_regex.fullmatch(minor):
-            logger.debug(f'Version {ver} ignored')
+            logger.debug(f'Version {ver} is ignored because all {minor} are ignored')
             continue
 
         patches = versions.get(minor)

--- a/workflows/openshift_test.py
+++ b/workflows/openshift_test.py
@@ -47,13 +47,13 @@ class TestOpenShift(unittest.TestCase):
     @patch('workflows.openshift.requests.get')
     def test_fetch_ocp_versions_ignored(self, mock_get, mock_settings):
         """Test that ignored versions are correctly filtered out."""
-        # Mock settings with a regex to ignore 4.10 and 4.12
-        mock_settings.ignored_versions = "4.10|4.12"
+        # Mock settings with a regex to ignore 4.10, 4.12 and 4.19.0-rc.1
+        mock_settings.ignored_versions = "^4.10$|^4.12$|^4.19.0-rc.1$"
         mock_settings.request_timeout_sec = 30
 
         # Mock API response
         mock_response = MagicMock()
-        mock_response.json.return_value = {'4-stable': ['4.10.1', '4.10.2', '4.11.0', '4.12.3']}
+        mock_response.json.return_value = {'4-stable': ['4.10.1', '4.10.2', '4.11.0', '4.12.3', '4.19.0-rc.0', '4.19.0-rc.1']}
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
 
@@ -61,8 +61,10 @@ class TestOpenShift(unittest.TestCase):
         result = fetch_ocp_versions()
 
         # Verify only the non-ignored version is included
+        # Only 4.11 and 4.19 should remain, but not 4.19.0-rc.1
         expected = {
-            '4.11': '4.11.0',  # Only 4.11 should remain
+            '4.11': '4.11.0',
+            '4.19': '4.19.0-rc.0'
         }
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
Add 4.19.0-rc.0 to the ignored versions because of an issue - the OS image is `rhel` and not `rhcos` as expected. See #169 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved version filtering to more precisely ignore specific OpenShift release candidate versions, ensuring that certain versions (such as 4.19.0-rc.0) are excluded as intended.

- **Tests**
	- Updated tests to verify that the new version filtering logic correctly excludes the specified versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->