### PR TITLE
Add 'rhel' to allowed OS labels

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/golang/glog"
@@ -20,7 +21,7 @@ const (
 )
 
 // AllNodeLabel checks if label is present on all nodes matching nodeSelector.
-func AllNodeLabel(apiClient *clients.Settings, nodeLabel, nodeLabelValue string,
+func AllNodeLabel(apiClient *clients.Settings, nodeLabel string, nodeLabelValues []string,
 	nodeSelector map[string]string) (bool, error) {
 	nodeBuilder, err := nodes.List(apiClient, v1.ListOptions{LabelSelector: labels.Set(nodeSelector).String()})
 
@@ -39,9 +40,9 @@ func AllNodeLabel(apiClient *clients.Settings, nodeLabel, nodeLabelValue string,
 	for _, node := range nodeBuilder {
 		labelValue := node.Object.Labels[nodeLabel]
 
-		if labelValue == nodeLabelValue {
-			glog.V(gpuparams.GpuLogLevel).Infof("Found label %v that contains %v with label value % s on "+
-				"node %v", nodeLabel, nodeLabel, nodeLabelValue, node.Object.Name)
+		if slices.Contains(nodeLabelValues, labelValue) {
+			glog.V(gpuparams.GpuLogLevel).Infof("Found label %v that contains %v with label value %s on "+
+				"node %v", nodeLabel, nodeLabel, labelValue, node.Object.Name)
 
 			foundLabels++
 			// if all nodes matching nodeSelector have this label with label value.
@@ -51,8 +52,8 @@ func AllNodeLabel(apiClient *clients.Settings, nodeLabel, nodeLabelValue string,
 		}
 	}
 
-	err = fmt.Errorf("not all (%v) nodes have the label '%s' with value '%s'", len(nodeBuilder),
-		nodeLabel, nodeLabelValue)
+	err = fmt.Errorf("not all (%v) nodes have the label '%s' with a value in '%v'", len(nodeBuilder),
+		nodeLabel, nodeLabelValues)
 
 	return false, err
 }

--- a/pkg/nfd/consts.go
+++ b/pkg/nfd/consts.go
@@ -2,11 +2,14 @@ package nfd
 
 import "time"
 
+func GetAllowedOSLabels() []string {
+	return []string{"rhcos", "rhel"}
+}
+
 const (
 	CustomNFDCatalogSourcePublisherName = "Red Hat"
 	CustomCatalogSourceDisplayName      = "Redhat Operators Custom"
-	RhcosLabel                          = "feature.node.kubernetes.io/system-os_release.ID"
-	RhcosLabelValue                     = "rhcos"
+	OSLabel                             = "feature.node.kubernetes.io/system-os_release.ID"
 	OperatorNamespace                   = "openshift-nfd"
 	CatalogSourceDefault                = "redhat-operators"
 	CatalogSourceNamespace              = "openshift-marketplace"

--- a/pkg/nfdcheck/checknfd.go
+++ b/pkg/nfdcheck/checknfd.go
@@ -2,6 +2,7 @@ package nfdcheck
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -9,11 +10,11 @@ import (
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
 )
 
-func CheckNfdInstallation(apiClient *clients.Settings, label, labelValue string, workerLabelMap map[string]string, logLevel int) {
+func CheckNfdInstallation(apiClient *clients.Settings, label string, allowedLabelValues []string, workerLabelMap map[string]string, logLevel int) {
 	By(fmt.Sprintf("Check if NFD is installed using label: %s", label))
-	nfdLabelDetected, err := check.AllNodeLabel(apiClient, label, labelValue, workerLabelMap)
+	nfdLabelDetected, err := check.AllNodeLabel(apiClient, label, allowedLabelValues, workerLabelMap)
 	Expect(err).ToNot(HaveOccurred(), "error calling check.NodeLabel: %v", err)
-	Expect(nfdLabelDetected).NotTo(BeFalse(), "NFD node label check failed to match label %s and label value %s on all nodes", label, labelValue)
+	Expect(nfdLabelDetected).NotTo(BeFalse(), "NFD node label check failed to match label %s and label values %v on all nodes", label, allowedLabelValues)
 	glog.V(glog.Level(logLevel)).Infof("The check for NFD label returned: %v", nfdLabelDetected)
 
 	isNfdInstalled, err := check.NFDDeploymentsReady(apiClient)

--- a/tests/nvidiagpu/deploy-gpu-test.go
+++ b/tests/nvidiagpu/deploy-gpu-test.go
@@ -247,7 +247,7 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 		It("Deploy NVIDIA GPU Operator with DTK", Label("nvidia-ci:gpu"), func() {
 
-			nfdcheck.CheckNfdInstallation(inittools.APIClient, nfd.RhcosLabel, nfd.RhcosLabelValue, inittools.GeneralConfig.WorkerLabelMap, networkparams.LogLevel)
+			nfdcheck.CheckNfdInstallation(inittools.APIClient, nfd.OSLabel, nfd.GetAllowedOSLabels(), inittools.GeneralConfig.WorkerLabelMap, networkparams.LogLevel)
 
 			By("Check if at least one worker node is GPU enabled")
 			gpuNodeFound, _ := check.NodeWithLabel(inittools.APIClient, nvidiagpu.NvidiaGPULabel, inittools.GeneralConfig.WorkerLabelMap)

--- a/tests/nvidianetwork/deploy-nno-test.go
+++ b/tests/nvidianetwork/deploy-nno-test.go
@@ -458,7 +458,7 @@ var _ = Describe("NNO", Ordered, Label(tsparams.LabelSuite), func() {
 
 		It("Deploy NVIDIA Network Operator with DTK", Label("nno"), func() {
 
-			nfdcheck.CheckNfdInstallation(inittools.APIClient, nfd.RhcosLabel, nfd.RhcosLabelValue, inittools.GeneralConfig.WorkerLabelMap, networkparams.LogLevel)
+			nfdcheck.CheckNfdInstallation(inittools.APIClient, nfd.OSLabel, nfd.GetAllowedOSLabels(), inittools.GeneralConfig.WorkerLabelMap, networkparams.LogLevel)
 
 			By("Check if at least one worker node is has label for Mellanox cards enabled")
 			networkNodeFound, _ := check.NodeWithLabel(inittools.APIClient, nvidiaNetworkLabel,


### PR DESCRIPTION
Starting with 4.19, OpenShift nodes will run a RHEL-based OS image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for verifying node labels by allowing checks against multiple allowed OS label values instead of a single value.

- **Refactor**
  - Updated label verification logic and related function signatures to accept and process multiple label values.
  - Replaced specific RHCOS label constants with a more general OS label and provided a function to retrieve all allowed OS labels.

- **Tests**
  - Adjusted test cases to use the new OS label and allowed values, ensuring compatibility with the updated label verification approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->