### PR TITLE
Allow applying a JSON patch to default ClusterPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ NVIDIA GPU Operator-specific parameters for the script are controlled by the fol
 - `NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL`: specific subscription channel to upgrade to from previous version.  _required when running operator-upgrade testcase_
 - `NVIDIAGPU_CLEANUP`: boolean flag to cleanup up resources created by testcase after testcase execution - Default value is true - _required only when cleanup is not needed_
 - `NVIDIAGPU_GPU_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`: custom certified-operators catalogsource index image for GPU package - _required when deploying fallback custom GPU catalogsource_
+- `NVIDIAGPU_GPU_CLUSTER_POLICY_PATCH`: a JSON patch to apply to a default cluster policy from ALM examples, written according to
+   [RFC 6902](http://tools.ietf.org/html/rfc6902) (also see [kubectl patch](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/)) - _optional_
 - `NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`:  custom redhat-operators catalogsource index image for NFD package - _required when deploying fallback custom NFD catalogsource_
 
 NVIDIA Network Operator-specific (NNO) parameters for the script are controlled by the following environment variables:
@@ -89,18 +91,18 @@ NVIDIA Network Operator-specific (NNO) parameters for the script are controlled 
 - `NVIDIANETWORK_CLEANUP`: boolean flag to cleanup up resources created by testcase after testcase execution - Default value is true - _required only when cleanup is not needed_
 - `NVIDIANETWORK_NNO_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`: custom certified-operators catalogsource index image for GPU package - _required when deploying fallback custom NNO catalogsource_
 - `NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`:  custom redhat-operators catalogsource index image for NFD package - _required when deploying fallback custom NFD catalogsource_
-- `NVIDIANETWORK_OFED_DRIVER_VERSION`: OFED Driver Version.  If not specified, the default driver version is used - _optional_    
-- `NVIDIANETWORK_OFED_REPOSITORY`:  OFED Driver Repository.   If not specified, the default repository is used - _optional_            
+- `NVIDIANETWORK_OFED_DRIVER_VERSION`: OFED Driver Version.  If not specified, the default driver version is used - _optional_
+- `NVIDIANETWORK_OFED_REPOSITORY`:  OFED Driver Repository.   If not specified, the default repository is used - _optional_
 - `NVIDIANETWORK_RDMA_WORKLOAD_NAMESPACE`:  RDMA workload pod namespace - _required_
 - `NVIDIANETWORK_RDMA_LINK_TYPE` Layer 2 link type, Infinband or Ethernet - _required_
-- `NVIDIANETWORK_RDMA_MLX_DEVICE:` mlx5 device ID corresponding to the interface port connected to Spectrum or Infiniband switch - _required_
-- `NVIDIANETWORK_RDMA_CLIENT_HOSTNAME:` RDMA Client hostname of first worker node for ib_write_bw test - _required when running the RDMA testcase_ 
-- `NVIDIANETWORK_RDMA_SERVER_HOSTNAME:` RDMA Server hostname of second worker node for ib_write_bw test - _required when running the RDMA testcase_   
-- `NVIDIANETWORK_RDMA_TEST_IMAGE:` RDMA Test Container Image that runs the entrypoint.sh script with optional arguments specified in the pod spec.  This container will clone the "https://github.com/linux-rdma/perftest" repo and builds the ib_write_bw binaries with or without cuda headers.  It will also run the ib_write_bw command with arguments either in CLient or Server mode.  Defaults to "quay.io/wabouham/ecosys-nvidia/rdma-tools:0.0.2" - _optional_
-- `NVIDIANETWORK_MELLANOX_ETH_INTERFACE_NAME`: Mellanox Ethernet Interface Name - Defaults to "ens8f0np0" if not specified - _optional_  
-- `NVIDIANETWORK_MELLANOX_IB_INTERFACE_NAME`:  Mellanox Infiniband Interface Name - Defaults to "ens8f0np0" if not specified - _optional_   
-- `NVIDIANETWORK_MACVLANNETWORK_NAME`: MacvlanNetwork Custom Resource instance name  - Defaults to name from Cluster Service Version alm-examples section if not specified  - _optional_ 
-- `NVIDIANETWORK_MACVLANNETWORK_IPAM_RANGE`: MacvlanNetwork Custom Resource instance IPAM or IP Address/Subnet mask range for Eth or IB interface - _required_    
+- `NVIDIANETWORK_RDMA_MLX_DEVICE`: mlx5 device ID corresponding to the interface port connected to Spectrum or Infiniband switch - _required_
+- `NVIDIANETWORK_RDMA_CLIENT_HOSTNAME`: RDMA Client hostname of first worker node for ib_write_bw test - _required when running the RDMA testcase_
+- `NVIDIANETWORK_RDMA_SERVER_HOSTNAME`: RDMA Server hostname of second worker node for ib_write_bw test - _required when running the RDMA testcase_
+- `NVIDIANETWORK_RDMA_TEST_IMAGE`: RDMA Test Container Image that runs the entrypoint.sh script with optional arguments specified in the pod spec.  This container will clone the "https://github.com/linux-rdma/perftest" repo and builds the ib_write_bw binaries with or without cuda headers.  It will also run the ib_write_bw command with arguments either in CLient or Server mode.  Defaults to "quay.io/wabouham/ecosys-nvidia/rdma-tools:0.0.2" - _optional_
+- `NVIDIANETWORK_MELLANOX_ETH_INTERFACE_NAME`: Mellanox Ethernet Interface Name - Defaults to "ens8f0np0" if not specified - _optional_
+- `NVIDIANETWORK_MELLANOX_IB_INTERFACE_NAME`:  Mellanox Infiniband Interface Name - Defaults to "ens8f0np0" if not specified - _optional_
+- `NVIDIANETWORK_MACVLANNETWORK_NAME`: MacvlanNetwork Custom Resource instance name  - Defaults to name from Cluster Service Version alm-examples section if not specified  - _optional_
+- `NVIDIANETWORK_MACVLANNETWORK_IPAM_RANGE`: MacvlanNetwork Custom Resource instance IPAM or IP Address/Subnet mask range for Eth or IB interface - _required_
 - `NVIDIANETWORK_MACVLANNETWORK_IPAM_GATEWAY`: MacvlanNetwork Custom Resource instance IPAM Default Gateway for specified ip address range - _required_
 
 ### Testing MPS with GPU Operator

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Mellanox/network-operator v1.4.0
 	github.com/NVIDIA/gpu-operator v1.8.3-0.20240924212236-e4f1f5d26c11
 	github.com/NVIDIA/k8s-operator-libs v0.0.0-20240826221728-249ba446fa35
+	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/golang/glog v1.2.4
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.22.2
@@ -39,7 +40,6 @@ require (
 	github.com/containernetworking/cni v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
-github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/internal/nvidiagpuconfig/config.go
+++ b/internal/nvidiagpuconfig/config.go
@@ -15,6 +15,7 @@ type NvidiaGPUConfig struct {
 	BundleImage                        string `envconfig:"NVIDIAGPU_BUNDLE_IMAGE"`
 	OperatorUpgradeToChannel           string `envconfig:"NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL"`
 	GPUFallbackCatalogsourceIndexImage string `envconfig:"NVIDIAGPU_GPU_FALLBACK_CATALOGSOURCE_INDEX_IMAGE"`
+	ClusterPolicyPatch                 string `envconfig:"NVIDIAGPU_GPU_CLUSTER_POLICY_PATCH"`
 }
 
 // NewNvidiaGPUConfig returns an instance of NvidiaGPUConfig.

--- a/pkg/olm/almexamples.go
+++ b/pkg/olm/almexamples.go
@@ -1,0 +1,42 @@
+package olm
+
+import (
+	"encoding/json"
+	"fmt"
+
+	k8sjson "k8s.io/apimachinery/pkg/util/json"
+)
+
+// GetALMExampleItem retrieves the ALM example item at the specified index as a raw JSON,
+// which can be later unmarshalled into custom resource objects. This can be useful if
+// the original JSON needs to be modified, e.g. patched.
+func GetALMExampleItem(index int, almExample string) (json.RawMessage, error) {
+	examples, err := GetALMExampleItems(almExample)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ALM example items: %w", err)
+	}
+
+	if index < 0 || len(examples) < index+1 {
+		return nil, fmt.Errorf("no alm examples item exists at index %d", index)
+	}
+
+	return examples[index], nil
+}
+
+// GetALMExampleItems retrieves a slice of raw JSON entries from an ALM example string.
+// The raw entries can be later unmarshalled into custom resource objects. This can be
+// useful if the original JSON needs to be modified (e.g. patched), or each entry will
+// be unmarshalled into an object of a different type.
+func GetALMExampleItems(almExample string) ([]json.RawMessage, error) {
+	if almExample == "" {
+		return nil, fmt.Errorf("almExample is an empty string")
+	}
+
+	var examples []json.RawMessage
+	err := k8sjson.Unmarshal([]byte(almExample), &examples)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ALM examples: %w", err)
+	}
+
+	return examples, nil
+}

--- a/vendor/github.com/evanphx/json-patch/v5/merge.go
+++ b/vendor/github.com/evanphx/json-patch/v5/merge.go
@@ -103,8 +103,8 @@ func pruneAryNulls(ary *partialArray, options *ApplyOptions) *partialArray {
 	return ary
 }
 
-var errBadJSONDoc = fmt.Errorf("Invalid JSON Document")
-var errBadJSONPatch = fmt.Errorf("Invalid JSON Patch")
+var ErrBadJSONDoc = fmt.Errorf("Invalid JSON Document")
+var ErrBadJSONPatch = fmt.Errorf("Invalid JSON Patch")
 var errBadMergeTypes = fmt.Errorf("Mismatched JSON Documents")
 
 // MergeMergePatches merges two merge patches together, such that
@@ -121,11 +121,11 @@ func MergePatch(docData, patchData []byte) ([]byte, error) {
 
 func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 	if !json.Valid(docData) {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	if !json.Valid(patchData) {
-		return nil, errBadJSONPatch
+		return nil, ErrBadJSONPatch
 	}
 
 	options := NewApplyOptions()
@@ -143,7 +143,7 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 	patchErr := patch.UnmarshalJSON(patchData)
 
 	if isSyntaxError(docErr) {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	if isSyntaxError(patchErr) {
@@ -151,7 +151,7 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 	}
 
 	if docErr == nil && doc.obj == nil {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	if patchErr == nil && patch.obj == nil {
@@ -175,7 +175,7 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 				if json.Valid(patchData) {
 					return patchData, nil
 				}
-				return nil, errBadJSONPatch
+				return nil, ErrBadJSONPatch
 			}
 
 			pruneAryNulls(patchAry, options)
@@ -183,7 +183,7 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 			out, patchErr := json.Marshal(patchAry.nodes)
 
 			if patchErr != nil {
-				return nil, errBadJSONPatch
+				return nil, ErrBadJSONPatch
 			}
 
 			return out, nil
@@ -256,12 +256,12 @@ func createObjectMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 
 	err := unmarshal(originalJSON, &originalDoc)
 	if err != nil {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	err = unmarshal(modifiedJSON, &modifiedDoc)
 	if err != nil {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	dest, err := getDiff(originalDoc, modifiedDoc)
@@ -286,17 +286,17 @@ func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 
 	err := unmarshal(originalJSON, &originalDocs)
 	if err != nil {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	err = unmarshal(modifiedJSON, &modifiedDocs)
 	if err != nil {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	total := len(originalDocs)
 	if len(modifiedDocs) != total {
-		return nil, errBadJSONDoc
+		return nil, ErrBadJSONDoc
 	}
 
 	result := []json.RawMessage{}

--- a/vendor/github.com/evanphx/json-patch/v5/patch.go
+++ b/vendor/github.com/evanphx/json-patch/v5/patch.go
@@ -2,13 +2,13 @@ package jsonpatch
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/evanphx/json-patch/v5/internal/json"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -461,7 +461,7 @@ func (o Operation) Path() (string, error) {
 		return op, nil
 	}
 
-	return "unknown", errors.Wrapf(ErrMissing, "operation missing path field")
+	return "unknown", fmt.Errorf("operation missing path field: %w", ErrMissing)
 }
 
 // From reads the "from" field of the Operation.
@@ -478,7 +478,7 @@ func (o Operation) From() (string, error) {
 		return op, nil
 	}
 
-	return "unknown", errors.Wrapf(ErrMissing, "operation, missing from field")
+	return "unknown", fmt.Errorf("operation, missing from field: %w", ErrMissing)
 }
 
 func (o Operation) value() *lazyNode {
@@ -511,7 +511,7 @@ func (o Operation) ValueInterface() (interface{}, error) {
 		return v, nil
 	}
 
-	return nil, errors.Wrapf(ErrMissing, "operation, missing value field")
+	return nil, fmt.Errorf("operation, missing value field: %w", ErrMissing)
 }
 
 func isArray(buf []byte) bool {
@@ -610,7 +610,7 @@ func (d *partialDoc) get(key string, options *ApplyOptions) (*lazyNode, error) {
 
 	v, ok := d.obj[key]
 	if !ok {
-		return v, errors.Wrapf(ErrMissing, "unable to get nonexistent key: %s", key)
+		return v, fmt.Errorf("unable to get nonexistent key: %s: %w", key, ErrMissing)
 	}
 	return v, nil
 }
@@ -625,7 +625,7 @@ func (d *partialDoc) remove(key string, options *ApplyOptions) error {
 		if options.AllowMissingPathOnRemove {
 			return nil
 		}
-		return errors.Wrapf(ErrMissing, "unable to remove nonexistent key: %s", key)
+		return fmt.Errorf("unable to remove nonexistent key: %s: %w", key, ErrMissing)
 	}
 	idx := -1
 	for i, k := range d.keys {
@@ -649,10 +649,10 @@ func (d *partialArray) set(key string, val *lazyNode, options *ApplyOptions) err
 
 	if idx < 0 {
 		if !options.SupportNegativeIndices {
-			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		if idx < -len(d.nodes) {
-			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		idx += len(d.nodes)
 	}
@@ -669,7 +669,7 @@ func (d *partialArray) add(key string, val *lazyNode, options *ApplyOptions) err
 
 	idx, err := strconv.Atoi(key)
 	if err != nil {
-		return errors.Wrapf(err, "value was not a proper array index: '%s'", key)
+		return fmt.Errorf("value was not a proper array index: '%s': %w", key, err)
 	}
 
 	sz := len(d.nodes) + 1
@@ -679,15 +679,15 @@ func (d *partialArray) add(key string, val *lazyNode, options *ApplyOptions) err
 	cur := d
 
 	if idx >= len(ary) {
-		return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 	}
 
 	if idx < 0 {
 		if !options.SupportNegativeIndices {
-			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		if idx < -len(ary) {
-			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		idx += len(ary)
 	}
@@ -713,16 +713,16 @@ func (d *partialArray) get(key string, options *ApplyOptions) (*lazyNode, error)
 
 	if idx < 0 {
 		if !options.SupportNegativeIndices {
-			return nil, errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return nil, fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		if idx < -len(d.nodes) {
-			return nil, errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return nil, fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		idx += len(d.nodes)
 	}
 
 	if idx >= len(d.nodes) {
-		return nil, errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		return nil, fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 	}
 
 	return d.nodes[idx], nil
@@ -740,18 +740,18 @@ func (d *partialArray) remove(key string, options *ApplyOptions) error {
 		if options.AllowMissingPathOnRemove {
 			return nil
 		}
-		return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+		return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 	}
 
 	if idx < 0 {
 		if !options.SupportNegativeIndices {
-			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		if idx < -len(cur.nodes) {
 			if options.AllowMissingPathOnRemove {
 				return nil
 			}
-			return errors.Wrapf(ErrInvalidIndex, "Unable to access invalid index: %d", idx)
+			return fmt.Errorf("Unable to access invalid index: %d: %w", idx, ErrInvalidIndex)
 		}
 		idx += len(cur.nodes)
 	}
@@ -768,7 +768,7 @@ func (d *partialArray) remove(key string, options *ApplyOptions) error {
 func (p Patch) add(doc *container, op Operation, options *ApplyOptions) error {
 	path, err := op.Path()
 	if err != nil {
-		return errors.Wrapf(ErrMissing, "add operation failed to decode path")
+		return fmt.Errorf("add operation failed to decode path: %w", ErrMissing)
 	}
 
 	// special case, adding to empty means replacing the container with the value given
@@ -809,12 +809,12 @@ func (p Patch) add(doc *container, op Operation, options *ApplyOptions) error {
 	con, key := findObject(doc, path, options)
 
 	if con == nil {
-		return errors.Wrapf(ErrMissing, "add operation does not apply: doc is missing path: \"%s\"", path)
+		return fmt.Errorf("add operation does not apply: doc is missing path: \"%s\": %w", path, ErrMissing)
 	}
 
 	err = con.add(key, op.value(), options)
 	if err != nil {
-		return errors.Wrapf(err, "error in add for path: '%s'", path)
+		return fmt.Errorf("error in add for path: '%s': %w", path, err)
 	}
 
 	return nil
@@ -867,11 +867,11 @@ func ensurePathExists(pd *container, path string, options *ApplyOptions) error {
 				if arrIndex < 0 {
 
 					if !options.SupportNegativeIndices {
-						return errors.Wrapf(ErrInvalidIndex, "Unable to ensure path for invalid index: %d", arrIndex)
+						return fmt.Errorf("Unable to ensure path for invalid index: %d: %w", arrIndex, ErrInvalidIndex)
 					}
 
 					if arrIndex < -1 {
-						return errors.Wrapf(ErrInvalidIndex, "Unable to ensure path for negative index other than -1: %d", arrIndex)
+						return fmt.Errorf("Unable to ensure path for negative index other than -1: %d: %w", arrIndex, ErrInvalidIndex)
 					}
 
 					arrIndex = 0
@@ -918,11 +918,11 @@ func validateOperation(op Operation) error {
 	switch op.Kind() {
 	case "add", "replace":
 		if _, err := op.ValueInterface(); err != nil {
-			return errors.Wrapf(err, "failed to decode 'value'")
+			return fmt.Errorf("failed to decode 'value': %w", err)
 		}
 	case "move", "copy":
 		if _, err := op.From(); err != nil {
-			return errors.Wrapf(err, "failed to decode 'from'")
+			return fmt.Errorf("failed to decode 'from': %w", err)
 		}
 	case "remove", "test":
 	default:
@@ -930,7 +930,7 @@ func validateOperation(op Operation) error {
 	}
 
 	if _, err := op.Path(); err != nil {
-		return errors.Wrapf(err, "failed to decode 'path'")
+		return fmt.Errorf("failed to decode 'path': %w", err)
 	}
 
 	return nil
@@ -941,10 +941,10 @@ func validatePatch(p Patch) error {
 		if err := validateOperation(op); err != nil {
 			opData, infoErr := json.Marshal(op)
 			if infoErr != nil {
-				return errors.Wrapf(err, "invalid operation")
+				return fmt.Errorf("invalid operation: %w", err)
 			}
 
-			return errors.Wrapf(err, "invalid operation %s", opData)
+			return fmt.Errorf("invalid operation %s: %w", opData, err)
 		}
 	}
 
@@ -954,7 +954,7 @@ func validatePatch(p Patch) error {
 func (p Patch) remove(doc *container, op Operation, options *ApplyOptions) error {
 	path, err := op.Path()
 	if err != nil {
-		return errors.Wrapf(ErrMissing, "remove operation failed to decode path")
+		return fmt.Errorf("remove operation failed to decode path: %w", ErrMissing)
 	}
 
 	con, key := findObject(doc, path, options)
@@ -963,12 +963,12 @@ func (p Patch) remove(doc *container, op Operation, options *ApplyOptions) error
 		if options.AllowMissingPathOnRemove {
 			return nil
 		}
-		return errors.Wrapf(ErrMissing, "remove operation does not apply: doc is missing path: \"%s\"", path)
+		return fmt.Errorf("remove operation does not apply: doc is missing path: \"%s\": %w", path, ErrMissing)
 	}
 
 	err = con.remove(key, options)
 	if err != nil {
-		return errors.Wrapf(err, "error in remove for path: '%s'", path)
+		return fmt.Errorf("error in remove for path: '%s': %w", path, err)
 	}
 
 	return nil
@@ -977,7 +977,7 @@ func (p Patch) remove(doc *container, op Operation, options *ApplyOptions) error
 func (p Patch) replace(doc *container, op Operation, options *ApplyOptions) error {
 	path, err := op.Path()
 	if err != nil {
-		return errors.Wrapf(err, "replace operation failed to decode path")
+		return fmt.Errorf("replace operation failed to decode path: %w", err)
 	}
 
 	if path == "" {
@@ -986,7 +986,7 @@ func (p Patch) replace(doc *container, op Operation, options *ApplyOptions) erro
 		if val.which == eRaw {
 			if !val.tryDoc() {
 				if !val.tryAry() {
-					return errors.Wrapf(err, "replace operation value must be object or array")
+					return fmt.Errorf("replace operation value must be object or array: %w", err)
 				}
 			} else {
 				val.doc.opts = options
@@ -999,7 +999,7 @@ func (p Patch) replace(doc *container, op Operation, options *ApplyOptions) erro
 		case eDoc:
 			*doc = val.doc
 		case eRaw:
-			return errors.Wrapf(err, "replace operation hit impossible case")
+			return fmt.Errorf("replace operation hit impossible case: %w", err)
 		}
 
 		return nil
@@ -1008,17 +1008,17 @@ func (p Patch) replace(doc *container, op Operation, options *ApplyOptions) erro
 	con, key := findObject(doc, path, options)
 
 	if con == nil {
-		return errors.Wrapf(ErrMissing, "replace operation does not apply: doc is missing path: %s", path)
+		return fmt.Errorf("replace operation does not apply: doc is missing path: %s: %w", path, ErrMissing)
 	}
 
 	_, ok := con.get(key, options)
 	if ok != nil {
-		return errors.Wrapf(ErrMissing, "replace operation does not apply: doc is missing key: %s", path)
+		return fmt.Errorf("replace operation does not apply: doc is missing key: %s: %w", path, ErrMissing)
 	}
 
 	err = con.set(key, op.value(), options)
 	if err != nil {
-		return errors.Wrapf(err, "error in remove for path: '%s'", path)
+		return fmt.Errorf("error in remove for path: '%s': %w", path, err)
 	}
 
 	return nil
@@ -1027,43 +1027,43 @@ func (p Patch) replace(doc *container, op Operation, options *ApplyOptions) erro
 func (p Patch) move(doc *container, op Operation, options *ApplyOptions) error {
 	from, err := op.From()
 	if err != nil {
-		return errors.Wrapf(err, "move operation failed to decode from")
+		return fmt.Errorf("move operation failed to decode from: %w", err)
 	}
 
 	if from == "" {
-		return errors.Wrapf(ErrInvalid, "unable to move entire document to another path")
+		return fmt.Errorf("unable to move entire document to another path: %w", ErrInvalid)
 	}
 
 	con, key := findObject(doc, from, options)
 
 	if con == nil {
-		return errors.Wrapf(ErrMissing, "move operation does not apply: doc is missing from path: %s", from)
+		return fmt.Errorf("move operation does not apply: doc is missing from path: %s: %w", from, ErrMissing)
 	}
 
 	val, err := con.get(key, options)
 	if err != nil {
-		return errors.Wrapf(err, "error in move for path: '%s'", key)
+		return fmt.Errorf("error in move for path: '%s': %w", key, err)
 	}
 
 	err = con.remove(key, options)
 	if err != nil {
-		return errors.Wrapf(err, "error in move for path: '%s'", key)
+		return fmt.Errorf("error in move for path: '%s': %w", key, err)
 	}
 
 	path, err := op.Path()
 	if err != nil {
-		return errors.Wrapf(err, "move operation failed to decode path")
+		return fmt.Errorf("move operation failed to decode path: %w", err)
 	}
 
 	con, key = findObject(doc, path, options)
 
 	if con == nil {
-		return errors.Wrapf(ErrMissing, "move operation does not apply: doc is missing destination path: %s", path)
+		return fmt.Errorf("move operation does not apply: doc is missing destination path: %s: %w", path, ErrMissing)
 	}
 
 	err = con.add(key, val, options)
 	if err != nil {
-		return errors.Wrapf(err, "error in move for path: '%s'", path)
+		return fmt.Errorf("error in move for path: '%s': %w", path, err)
 	}
 
 	return nil
@@ -1072,7 +1072,7 @@ func (p Patch) move(doc *container, op Operation, options *ApplyOptions) error {
 func (p Patch) test(doc *container, op Operation, options *ApplyOptions) error {
 	path, err := op.Path()
 	if err != nil {
-		return errors.Wrapf(err, "test operation failed to decode path")
+		return fmt.Errorf("test operation failed to decode path: %w", err)
 	}
 
 	if path == "" {
@@ -1091,18 +1091,18 @@ func (p Patch) test(doc *container, op Operation, options *ApplyOptions) error {
 			return nil
 		}
 
-		return errors.Wrapf(ErrTestFailed, "testing value %s failed", path)
+		return fmt.Errorf("testing value %s failed: %w", path, ErrTestFailed)
 	}
 
 	con, key := findObject(doc, path, options)
 
 	if con == nil {
-		return errors.Wrapf(ErrMissing, "test operation does not apply: is missing path: %s", path)
+		return fmt.Errorf("test operation does not apply: is missing path: %s: %w", path, ErrMissing)
 	}
 
 	val, err := con.get(key, options)
-	if err != nil && errors.Cause(err) != ErrMissing {
-		return errors.Wrapf(err, "error in test for path: '%s'", path)
+	if err != nil && errors.Unwrap(err) != ErrMissing {
+		return fmt.Errorf("error in test for path: '%s': %w", path, err)
 	}
 
 	ov := op.value()
@@ -1111,49 +1111,49 @@ func (p Patch) test(doc *container, op Operation, options *ApplyOptions) error {
 		if ov.isNull() {
 			return nil
 		}
-		return errors.Wrapf(ErrTestFailed, "testing value %s failed", path)
+		return fmt.Errorf("testing value %s failed: %w", path, ErrTestFailed)
 	} else if ov.isNull() {
-		return errors.Wrapf(ErrTestFailed, "testing value %s failed", path)
+		return fmt.Errorf("testing value %s failed: %w", path, ErrTestFailed)
 	}
 
 	if val.equal(op.value()) {
 		return nil
 	}
 
-	return errors.Wrapf(ErrTestFailed, "testing value %s failed", path)
+	return fmt.Errorf("testing value %s failed: %w", path, ErrTestFailed)
 }
 
 func (p Patch) copy(doc *container, op Operation, accumulatedCopySize *int64, options *ApplyOptions) error {
 	from, err := op.From()
 	if err != nil {
-		return errors.Wrapf(err, "copy operation failed to decode from")
+		return fmt.Errorf("copy operation failed to decode from: %w", err)
 	}
 
 	con, key := findObject(doc, from, options)
 
 	if con == nil {
-		return errors.Wrapf(ErrMissing, "copy operation does not apply: doc is missing from path: \"%s\"", from)
+		return fmt.Errorf("copy operation does not apply: doc is missing from path: \"%s\": %w", from, ErrMissing)
 	}
 
 	val, err := con.get(key, options)
 	if err != nil {
-		return errors.Wrapf(err, "error in copy for from: '%s'", from)
+		return fmt.Errorf("error in copy for from: '%s': %w", from, err)
 	}
 
 	path, err := op.Path()
 	if err != nil {
-		return errors.Wrapf(ErrMissing, "copy operation failed to decode path")
+		return fmt.Errorf("copy operation failed to decode path: %w", ErrMissing)
 	}
 
 	con, key = findObject(doc, path, options)
 
 	if con == nil {
-		return errors.Wrapf(ErrMissing, "copy operation does not apply: doc is missing destination path: %s", path)
+		return fmt.Errorf("copy operation does not apply: doc is missing destination path: %s: %w", path, ErrMissing)
 	}
 
 	valCopy, sz, err := deepCopy(val, options)
 	if err != nil {
-		return errors.Wrapf(err, "error while performing deep copy")
+		return fmt.Errorf("error while performing deep copy: %w", err)
 	}
 
 	(*accumulatedCopySize) += int64(sz)
@@ -1163,7 +1163,7 @@ func (p Patch) copy(doc *container, op Operation, accumulatedCopySize *int64, op
 
 	err = con.add(key, valCopy, options)
 	if err != nil {
-		return errors.Wrapf(err, "error while adding value during copy")
+		return fmt.Errorf("error while adding value during copy: %w", err)
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.13
 github.com/emicklei/go-restful/v3
 github.com/emicklei/go-restful/v3/log
-# github.com/evanphx/json-patch/v5 v5.9.0
+# github.com/evanphx/json-patch/v5 v5.9.11
 ## explicit; go 1.18
 github.com/evanphx/json-patch/v5
 github.com/evanphx/json-patch/v5/internal/json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for applying a JSON patch to the default NVIDIA GPU Operator cluster policy using a new optional environment variable.
- **Documentation**
  - Updated README to document the new environment variable and corrected minor formatting inconsistencies.
- **Bug Fixes**
  - Improved handling and extraction of ALM example JSON objects for more robust cluster policy customization.
- **Chores**
  - Updated dependencies for improved compatibility and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->