### PR TITLE
Adding NFD must gather script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,27 @@ unit-test:
 	go test github.com/rh-ecosystem-edge/nvidia-ci/$(TEST)
 
 get-gpu-operator-must-gather:
-	test -s gpu-operator-must-gather.sh || (\
+	test -s scripts/gpu-operator-must-gather.sh || (\
     		SCRIPT_URL="https://raw.githubusercontent.com/NVIDIA/gpu-operator/v23.9.1/hack/must-gather.sh" && \
-    		if ! curl -SsL -o gpu-operator-must-gather.sh -L $$SCRIPT_URL; then \
+    		if ! curl -SsL -o scripts/gpu-operator-must-gather.sh -L $$SCRIPT_URL; then \
     			echo "Failed to download must-gather script" >&2; \
     			exit 1; \
     		fi && \
-    		chmod +x gpu-operator-must-gather.sh \
+    		chmod +x scripts/gpu-operator-must-gather.sh \
     	)
 
-run-tests: get-gpu-operator-must-gather
+get-nfd-must-gather:
+	# TODO: change it to use release branch when it will be released
+	test -s scripts/nfd-must-gather.sh || (\
+		SCRIPT_URL="https://raw.githubusercontent.com/openshift/cluster-nfd-operator/c93914db38232ebf2abf62fa8028c23a154a5048/must-gather/gather" && \
+		if ! curl -SsL -o scripts/nfd-must-gather.sh -L $$SCRIPT_URL; then \
+			echo "Failed to download NFD must-gather script" >&2; \
+			exit 1; \
+		fi && \
+		chmod +x scripts/nfd-must-gather.sh \
+	)
+
+run-tests: get-gpu-operator-must-gather get-nfd-must-gather
 	@echo "Executing nvidiagpu test-runner script"
 	scripts/test-runner.sh
 

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -134,15 +134,11 @@ func removeFile(fPath string) error {
 	return nil
 }
 
-func RunMustGather(artifactDir string, timeout time.Duration) error {
+func RunMustGather(artifactDir, mustGatherScriptPath string, timeout time.Duration) error {
 	if artifactDir == "" {
 		return fmt.Errorf("artifact directory cannot be empty")
 	}
 
-	mustGatherScriptPath := os.Getenv("PATH_TO_MUST_GATHER_SCRIPT")
-	if mustGatherScriptPath == "" {
-		return fmt.Errorf("PATH_TO_MUST_GATHER_SCRIPT environment variable is not set")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/scripts/gpu-operator-tests-must-gather.sh
+++ b/scripts/gpu-operator-tests-must-gather.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Get the directory where this script is located
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default to must-gather dir
+ARTIFACT_DIR="${ARTIFACT_DIR:-must-gather}"
+
+
+# Collect NFD operator must-gather
+NFD_ARTIFACT_DIR="${ARTIFACT_DIR}/nfd-must-gather"
+mkdir -p "${NFD_ARTIFACT_DIR}"
+echo "Collecting NFD operator must-gather in ${NFD_ARTIFACT_DIR}"
+OUTPUT_DIR="${NFD_ARTIFACT_DIR}" "$SCRIPTS_DIR/nfd-must-gather.sh"
+
+
+# Collect GPU operator must-gather 
+GPU_ARTIFACT_DIR="${ARTIFACT_DIR}/gpu-must-gather"
+mkdir -p "${GPU_ARTIFACT_DIR}"
+echo "Collecting GPU operator must-gather in ${GPU_ARTIFACT_DIR}"
+ARTIFACT_DIR="${GPU_ARTIFACT_DIR}" "$SCRIPTS_DIR/gpu-operator-must-gather.sh"

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -46,7 +46,7 @@ fi
 
 
 # Build ginkgo command
-cmd="PATH_TO_MUST_GATHER_SCRIPT=$(pwd)/gpu-operator-must-gather.sh ginkgo -timeout=24h --keep-going --require-suite -r"
+cmd="PATH_TO_MUST_GATHER_SCRIPT=$(pwd)/scripts/gpu-operator-tests-must-gather.sh ginkgo -timeout=24h --keep-going --require-suite -r"
 
 if [[ "${TEST_VERBOSE}" == "true" ]]; then
     cmd+=" -vv"

--- a/tests/nvidiagpu/gpu_suite_test.go
+++ b/tests/nvidiagpu/gpu_suite_test.go
@@ -1,10 +1,12 @@
 package nvidiagpu
 
 import (
-	"github.com/golang/glog"
+	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/golang/glog"
 
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/reporter"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
@@ -30,8 +32,12 @@ var _ = JustAfterEach(func() {
 	specReport := CurrentSpecReport()
 	reporter.ReportIfFailed(
 		specReport, currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
-	artifactDir := inittools.GeneralConfig.GetReportPath("gpu-must-gather")
-	if err := reporter.RunMustGather(artifactDir, 5*time.Minute); err != nil {
-		glog.Errorf("Failed to collect must-gather for the GPU operator, %v", err)
+
+	scriptPath := os.Getenv("PATH_TO_MUST_GATHER_SCRIPT")
+	if scriptPath != "" {
+		artifactDir := inittools.GeneralConfig.GetReportPath("gpu-operator-tests-must-gather")
+		if err := reporter.RunMustGather(artifactDir, scriptPath, 5*time.Minute); err != nil {
+			glog.Errorf("Failed to collect must-gather: %v", err)
+		}
 	}
 })


### PR DESCRIPTION
Downloading the must gather script from NFD and running it after each run.

---

/assign @empovit 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running multiple must-gather scripts, including both GPU and NFD must-gather scripts, during test execution.
  * Introduced a new combined must-gather script to collect data for both NFD and GPU operators.

* **Chores**
  * Updated test and script handling to ensure both must-gather scripts are downloaded and properly referenced before running tests.
  * Improved error reporting and logging for must-gather script execution in test suites.
  * Refined script locations and environment variable usage for must-gather operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->