### PR TITLE
Upgrade to Go 1.24.4 and resolve linting issues

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 FROM quay.io/openshift/origin-cli:4.20 as oc-cli
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4
 
 LABEL org.opencontainers.image.authors="Red Hat Ecosystem Engineering"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rh-ecosystem-edge/nvidia-ci
 
-go 1.22.9
+go 1.24.4
 
 require (
 	github.com/Mellanox/network-operator v1.4.0

--- a/internal/inittools/inittools.go
+++ b/internal/inittools/inittools.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 
 	"github.com/golang/glog"
-	"github.com/onsi/ginkgo/v2"
+	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/config"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -2,6 +2,7 @@ package configmap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -224,7 +225,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
+		return false, errors.New(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
@@ -236,7 +237,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -449,7 +450,7 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if _, err := builder.Create(); err != nil {
-		return nil, fmt.Errorf(err.Error())
+		return nil, err
 	}
 
 	if builder.IsReady(timeout) {
@@ -587,7 +588,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
+		return false, errors.New(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
@@ -599,7 +600,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/machine/machineset.go
+++ b/pkg/machine/machineset.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -577,7 +578,7 @@ func (builder *SetBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -2,7 +2,9 @@ package namespace
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/golang/glog"
@@ -15,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
-	"k8s.io/utils/strings/slices"
 )
 
 // Builder provides struct for namespace object containing connection to the cluster and the namespace definitions.
@@ -351,7 +352,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/nfd/nodefeaturediscovery.go
+++ b/pkg/nfd/nodefeaturediscovery.go
@@ -3,6 +3,7 @@ package nfd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -247,7 +248,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(LogLevel).Infof("The %s is undefined", resourceCRD)
 
-		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
+		return false, errors.New(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {

--- a/pkg/nfd/nodefeaturediscoveryconfig.go
+++ b/pkg/nfd/nodefeaturediscoveryconfig.go
@@ -3,7 +3,7 @@ package nfd
 import (
 	"log"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Config worker-config.

--- a/pkg/nodes/list.go
+++ b/pkg/nodes/list.go
@@ -3,13 +3,13 @@ package nodes
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/strings/slices"
 )
 
 const (

--- a/pkg/nodes/node.go
+++ b/pkg/nodes/node.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -289,7 +290,7 @@ func (builder *Builder) ExternalIPv4Network() (string, error) {
 	}
 
 	if builder.errorMsg != "" {
-		return "", fmt.Errorf(builder.errorMsg)
+		return "", errors.New(builder.errorMsg)
 	}
 
 	var extNetwork ExternalNetworks
@@ -422,7 +423,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/nvidiagpu/clusterpolicy.go
+++ b/pkg/nvidiagpu/clusterpolicy.go
@@ -2,6 +2,7 @@ package nvidiagpu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -268,7 +269,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/nvidianetwork/ipoibnetwork.go
+++ b/pkg/nvidianetwork/ipoibnetwork.go
@@ -2,7 +2,9 @@ package nvidianetwork
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	nvidianetworkv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 
 	"github.com/golang/glog"
@@ -114,7 +116,7 @@ func PullIPoIBNetwork(apiClient *clients.Settings, name string) (*IPoIBNetworkBu
 		glog.V(100).Infof("IPoIBNetwork name is empty")
 
 		builder.errorMsg = "IPoIBNetwork 'name' cannot be empty"
-		return nil, fmt.Errorf(builder.errorMsg)
+		return nil, errors.New(builder.errorMsg)
 	}
 
 	if !builder.Exists() {
@@ -275,7 +277,7 @@ func (builder *IPoIBNetworkBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/nvidianetwork/macvlannetwork.go
+++ b/pkg/nvidianetwork/macvlannetwork.go
@@ -2,7 +2,9 @@ package nvidianetwork
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	nvidianetworkv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 
 	"github.com/golang/glog"
@@ -114,7 +116,7 @@ func PullMacvlanNetwork(apiClient *clients.Settings, name string) (*MacvlanNetwo
 		glog.V(100).Infof("MacvlanNetwork name is empty")
 
 		builder.errorMsg = "MacvlanNetwork 'name' cannot be empty"
-		return nil, fmt.Errorf(builder.errorMsg)
+		return nil, errors.New(builder.errorMsg)
 	}
 
 	if !builder.Exists() {
@@ -154,7 +156,7 @@ func (builder *MacvlanNetworkBuilder) Delete() (*MacvlanNetworkBuilder, error) {
 	glog.V(100).Infof("Deleting MacvlanNetwork %s", builder.Definition.Name)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("MacvlanNetwork cannot be deleted because it does not exist")
+		return builder, errors.New("MacvlanNetwork cannot be deleted because it does not exist")
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
@@ -226,7 +228,7 @@ func getMacvlanNetworkFromAlmExample(almExample string) (*nvidianetworkv1alpha1.
 	MacvlanNetworkList := &nvidianetworkv1alpha1.MacvlanNetworkList{}
 
 	if almExample == "" {
-		return nil, fmt.Errorf("almExample is an empty string")
+		return nil, errors.New("almExample is an empty string")
 	}
 
 	err := json.Unmarshal([]byte(almExample), &MacvlanNetworkList.Items)
@@ -238,7 +240,7 @@ func getMacvlanNetworkFromAlmExample(almExample string) (*nvidianetworkv1alpha1.
 	}
 
 	if len(MacvlanNetworkList.Items) == 0 {
-		return nil, fmt.Errorf("failed to get alm examples")
+		return nil, errors.New("failed to get alm examples")
 	}
 
 	for i := range MacvlanNetworkList.Items {
@@ -247,7 +249,7 @@ func getMacvlanNetworkFromAlmExample(almExample string) (*nvidianetworkv1alpha1.
 		}
 	}
 
-	return nil, fmt.Errorf("MacvlanNetwork not found in alm examples")
+	return nil, errors.New("MacvlanNetwork not found in alm examples")
 }
 
 // validate will check that the builder and builder definition are properly initialized before
@@ -275,7 +277,7 @@ func (builder *MacvlanNetworkBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/nvidianetwork/nicclusterpolicy.go
+++ b/pkg/nvidianetwork/nicclusterpolicy.go
@@ -2,7 +2,9 @@ package nvidianetwork
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	nvidianetworkv1alpha1 "github.com/Mellanox/network-operator/api/v1alpha1"
 
 	"github.com/golang/glog"
@@ -114,7 +116,7 @@ func PullNicClusterPolicy(apiClient *clients.Settings, name string) (*NicCluster
 		glog.V(100).Infof("NicClusterPolicy name is empty")
 
 		builder.errorMsg = "NicClusterPolicy 'name' cannot be empty"
-		return nil, fmt.Errorf(builder.errorMsg)
+		return nil, errors.New(builder.errorMsg)
 	}
 
 	if !builder.Exists() {
@@ -275,7 +277,7 @@ func (builder *NicClusterPolicyBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/olm/catalogsource.go
+++ b/pkg/olm/catalogsource.go
@@ -2,9 +2,11 @@ package olm
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/golang/glog"
 	oplmV1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -265,7 +267,7 @@ func (builder *CatalogSourceBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/olm/clusterserviceversion.go
+++ b/pkg/olm/clusterserviceversion.go
@@ -2,6 +2,7 @@ package olm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -187,7 +188,7 @@ func (builder *ClusterServiceVersionBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/olm/installplan.go
+++ b/pkg/olm/installplan.go
@@ -2,6 +2,7 @@ package olm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/msg"
@@ -156,7 +157,7 @@ func (builder *InstallPlanBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The builder %s has error message: %w", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/olm/operatorgroup.go
+++ b/pkg/olm/operatorgroup.go
@@ -2,6 +2,7 @@ package olm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -200,7 +201,7 @@ func (builder *OperatorGroupBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/olm/packagemanifest.go
+++ b/pkg/olm/packagemanifest.go
@@ -2,7 +2,10 @@ package olm
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
+
 	"github.com/golang/glog"
 	pkgManifestV1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
@@ -10,7 +13,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"time"
 )
 
 // PackageManifestBuilder provides a struct for PackageManifest object from the cluster
@@ -227,7 +229,7 @@ func (builder *PackageManifestBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/olm/subscription.go
+++ b/pkg/olm/subscription.go
@@ -2,6 +2,7 @@ package olm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -294,7 +295,7 @@ func (builder *SubscriptionBuilder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/pod/container.go
+++ b/pkg/pod/container.go
@@ -1,13 +1,13 @@
 package pod
 
 import (
-	"fmt"
+	"errors"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/strings/slices"
 )
 
 var (
@@ -382,7 +382,7 @@ func (builder *ContainerBuilder) GetContainerCfg() (*corev1.Container, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("Failed to build container configuration due to %s", builder.errorMsg)
 
-		return nil, fmt.Errorf(builder.errorMsg)
+		return nil, errors.New(builder.errorMsg)
 	}
 
 	return builder.definition, nil

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1204,7 +1205,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.errorMsg != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
 
-		return false, fmt.Errorf(builder.errorMsg)
+		return false, errors.New(builder.errorMsg)
 	}
 
 	return true, nil

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname "$0")"/common.sh
 
-GOLANGCI_LINT_VERSION="1.55.2"
+GOLANGCI_LINT_VERSION="1.64.8"
 # This is required because the Openshift CI is running this test as a non-root
 # user but whitin the / directory as the home directory, therefore, the linter
 # won't have the permissions to create the `/.cache` directory.


### PR DESCRIPTION
- Update Go version and base image to 1.24.4
- Upgrade golangci-lint to v1.64.8 for compatibility
- Replace deprecated k8s.io/utils/strings/slices with stdlib slices
- Fix fmt.Errorf() usage for non-formatted error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolset and module version to 1.24.4.
  * Upgraded golangci-lint version to 1.64.8.
  * Refreshed container base image for Go to 1.24.4.

* **Refactor**
  * Simplified error handling throughout the application by replacing formatted error creation with direct error instantiation for static messages.
  * Updated import statements to use standard library packages where applicable and clarified import aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->