### PR TITLE
Update GPU operator reports manually

### DIFF
--- a/gpu_operator_matrix.html
+++ b/gpu_operator_matrix.html
@@ -37,62 +37,13 @@
 
 <div class="toc">
     <div class="ocp-version-header">OpenShift Versions</div>
-    <a href="#ocp-4.20">4.20</a>, <a href="#ocp-4.19">4.19</a>, <a href="#ocp-4.18">4.18</a>, <a href="#ocp-4.17">4.17</a>, <a href="#ocp-4.16">4.16</a>, <a href="#ocp-4.15">4.15</a>, <a href="#ocp-4.14">4.14</a>, <a href="#ocp-4.13">4.13</a>, <a href="#ocp-4.12">4.12</a>
-</div>
-      <a id="ocp-4.20"></a>
-  <div class="ocp-version-container">
-    <div class="ocp-version-header">
-      OpenShift 4.20
-    </div>
-    
-    <div class="section-label">From operator catalog</div>
-    <table id="table-4.20-regular">
-      <thead>
-        <tr>
-          <th>OpenShift</th>
-          <th>NVIDIA GPU Operator</th>
-        </tr>
-      </thead>
-      <tbody>
-        
-      </tbody>
-    </table>
-    
-  <div class="section-label">
-    <strong>From main branch (OLM bundle)</strong>
-  </div>
-  <div class="history-bar-inner history-bar-outer">
-    <div style="margin-top: 5px;">
-      <strong>Last Bundle Job Date:</strong> 2025-07-21 09:18:54 UTC
-    </div>
-    
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.20-stable-nvidia-gpu-operator-e2e-24-9-x/1947224608562221056", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-07-21 09:18:54 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.20-stable-nvidia-gpu-operator-e2e-25-3-x/1947224610751647744", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-07-21 09:18:49 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.20-stable-nvidia-gpu-operator-e2e-master/1947224612429369344", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-07-21 09:18:49 UTC
-         </span>
-    </div>
-        </div>
+    <a href="#ocp-4.19">4.19</a>, <a href="#ocp-4.18">4.18</a>, <a href="#ocp-4.17">4.17</a>, <a href="#ocp-4.16">4.16</a>, <a href="#ocp-4.15">4.15</a>, <a href="#ocp-4.14">4.14</a>, <a href="#ocp-4.13">4.13</a>, <a href="#ocp-4.12">4.12</a>
   </div>  <a id="ocp-4.19"></a>
   <div class="ocp-version-container">
     <div class="ocp-version-header">
       OpenShift 4.19
     </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.19-regular">
       <thead>
@@ -102,235 +53,193 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.19.6</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/253/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1950120170907242496" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091600732160" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1948668610880737280" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.19.5</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/249/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1947992878374457344" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1947195546607292416" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.19.4</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1944646479603830784" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1944646479440252928" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.19.3</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1941740110919766016" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1941740109636308992" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.19.2</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/219/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1939207229274066944" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/219/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1939207229085323264" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.19.1</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/214/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1937810690098073600" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/214/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1937810690039353344" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.19.0</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/195/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1934055116692787200" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/188/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1930578944256380928" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/195/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1934055116642455552" target="_blank">24.9.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
   <div class="history-bar-inner history-bar-outer">
     <div style="margin-top: 5px;">
-      <strong>Last Bundle Job Date:</strong> 2025-07-29 08:30:27 UTC
+      <strong>Last Bundle Job Date:</strong> 2025-07-25 10:52:40 UTC
     </div>
-    
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/253/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1950086423147188224", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-07-29 08:30:27 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/253/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1949937783602679808", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-07-28 21:59:56 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1948668617285439488", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-25 10:52:40 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1947224604862844928", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:28:40 UTC
          </span>
     </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1947224600689512448", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:28:28 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1947224602354651136", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:28:24 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1947195546699567104", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-21 08:59:29 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1944646479670939648", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-14 08:25:06 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/230/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1943587465981857792", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-11 10:08:37 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/229/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1943243541077561344", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-10 11:34:08 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/225/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1942460217803411456", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-08 07:32:52 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1941740117626458112", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-06 07:57:35 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/222/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1940323052923392000", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-02 10:00:15 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/216/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1938152667855458304", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-26 10:04:53 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/214/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1937810690131628032", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-25 11:30:39 UTC
          </span>
     </div>
-        
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/209/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-25-3-x/1936372460769251328", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-06-21 11:51:57 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/209/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-24-9-x/1936372460710531072", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-06-21 11:44:27 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-failure'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/208/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1935943485945286656", "_blank")'>
          <span class="history-square-tooltip">
           Status: FAILURE | Timestamp: 2025-06-20 07:29:22 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-failure'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/203/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1935371730700734464", "_blank")'>
          <span class="history-square-tooltip">
           Status: FAILURE | Timestamp: 2025-06-18 17:21:31 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/189/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1931066803757256704", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-06 20:47:46 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/188/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1930578944331878400", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-05 12:35:29 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/187/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1929101052196425728", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-01 10:33:05 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/181/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1925044893814624256", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-21 06:12:11 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/180/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1924707742665150464", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-20 07:36:23 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1923595969992069120", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-17 06:10:44 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/175/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1923244465728786432", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-16 06:44:36 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/172/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.19-stable-nvidia-gpu-operator-e2e-master/1922906477907939328", "_blank")'>
          <span class="history-square-tooltip">
@@ -343,7 +252,7 @@
     <div class="ocp-version-header">
       OpenShift 4.18
     </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.18-regular">
       <thead>
@@ -353,105 +262,105 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.18.21</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091546206208" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1948668610813628416" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1948668610784268288" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.20</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1944646479385726976" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1944646479343783936" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.19</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/219/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1939207229034991616" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/219/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1939207228997242880" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.18</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/209/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1936372460630839296" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/209/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1936372460563730432" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.17</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/193/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1933427557370171392" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/189/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1931066803715313664" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/189/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1931066803673370624" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.16</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1928296519530713088" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1928296519488770048" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.15</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/184/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1925725054553821184" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/184/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1925725054499295232" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.14</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1923595955442028544" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1923595955278450688" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.13</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1920691946058158080" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1920691941872242688" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.12</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/162/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1918133410795098112" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/162/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1918133410769932288" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.11</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/155/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1917088809418231808" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/155/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1917088809367900160" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.10</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/150/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1913461457320677376" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/150/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1913461457278734336" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.9</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/144/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1910570483498094592" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/144/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1910570483456151552" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.8</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/138/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1908025762691158016" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/138/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1908025752020848640" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.7</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1905620207271940096" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/118/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1905651260355252224" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.6</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/107/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1903023446225326080" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/107/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-6-x/1903023446166605824" target="_blank">24.6.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.5</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/105/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1902589945051090944" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/105/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-6-x/1902589945013342208" target="_blank">24.6.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.4</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/95/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-6-x/1900165203165712384" target="_blank">24.6.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.18.2</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/71/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1896267192433905664" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/71/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-6-x/1896267192396156928" target="_blank">24.6.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
@@ -459,196 +368,175 @@
     <div style="margin-top: 5px;">
       <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:20 UTC
     </div>
-    
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-25-3-x/1947224594796515328", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:20 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1947224597321486336", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:25:20 UTC
          </span>
     </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1947224592326070272", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:17 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/172/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1922906477870190592", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-15 08:30:42 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/171/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1922545853269020672", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-14 08:22:07 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/168/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1921012693439877120", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-10 02:59:22 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/166/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1919971384897835008", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-07 06:01:34 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/164/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1919664775692816384", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-06 09:54:32 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/160/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1917426578422239232", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-30 05:28:49 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/155/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1917088809476952064", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-29 06:59:00 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/153/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1915979125651148800", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-26 05:26:34 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/152/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1915578224352432128", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-25 03:00:34 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/145/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1910909077475561472", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-12 05:43:17 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/140/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1909788238751469568", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-09 03:34:53 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/136/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1907676393257308160", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-03 07:40:38 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/133/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1907304664307601408", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-02 07:10:48 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/129/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1906897856535465984", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-01 04:09:56 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1905620209780133888", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-28 15:39:13 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/108/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1903375956551143424", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-22 11:49:03 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/107/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1903023446292434944", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-21 11:30:52 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/105/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1902589945093033984", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-20 06:49:55 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/96/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1900799120092696576", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-15 08:15:50 UTC
          </span>
     </div>
-        
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/95/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-24-9-x/1900165203190878208", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-03-13 15:59:00 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/95/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1900165203119575040", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-13 14:10:14 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/93/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1900095474199695360", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-13 09:54:22 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/71/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1896267192475848704", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-02 20:04:54 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/61/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1896219569295462400", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-03-02 17:00:25 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/59/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.18-stable-nvidia-gpu-operator-e2e-master/1896132286877798400", "_blank")'>
          <span class="history-square-tooltip">
@@ -661,7 +549,7 @@
     <div class="ocp-version-header">
       OpenShift 4.17
     </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.17-regular">
       <thead>
@@ -671,131 +559,117 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.17.36</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091500068864" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/239/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1946064209741615104" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/239/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1946064209712254976" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.35</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1941740109585977344" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1941780740035317760" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.34</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/208/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1935943485903343616" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/208/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1935943485773320192" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.33</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/193/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1933427557311451136" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/189/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1931066803639816192" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/189/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1931066803585290240" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.32</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1928296519446827008" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1928296519400689664" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.31</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/184/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1925725054448963584" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/184/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1925725054419603456" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.30</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1923595955228119040" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1923595955194564608" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.29</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1920728781031477248" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1920691940676866048" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.28</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/163/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1918510471606964224" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/163/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1918510471560826880" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.27</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/153/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1915979125596622848" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/153/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1915979125550485504" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.26</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/150/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1913461457236791296" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/150/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1913461457194848256" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.25</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/145/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1910909077437812736" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/145/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1910909077383286784" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.24</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/138/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1908025751987294208" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/138/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1908065281813516288" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.23</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1905620204742774784" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/118/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1905651257834475520" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.22</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/107/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1903023446128857088" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/107/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-6-x/1903023446091108352" target="_blank">24.6.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.20</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/95/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1900165202855333888" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/95/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-6-x/1900165202884694016" target="_blank">24.6.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.17.19</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/69/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1896268990100017152" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/69/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-6-x/1896268990045491200" target="_blank">24.6.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
   <div class="history-bar-inner history-bar-outer">
     <div style="margin-top: 5px;">
-      <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:22 UTC
+      <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:16 UTC
     </div>
-    
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-25-3-x/1947224585585823744", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:22 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-24-9-x/1947224583052464128", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:16 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-master/1947224587250962432", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:25:16 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/69/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-master/1896268990167126016", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-02 20:15:26 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/61/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.17-stable-nvidia-gpu-operator-e2e-master/1896219569261907968", "_blank")'>
          <span class="history-square-tooltip">
@@ -808,7 +682,7 @@
     <div class="ocp-version-header">
       OpenShift 4.16
     </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.16-regular">
       <thead>
@@ -818,91 +692,77 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.16.45</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091466514432" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1948668610595524608" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1948668610503249920" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.44</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1944646479297646592" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1944646479251509248" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.43</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/218/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1938549364402163712" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/218/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1938549364356026368" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.42</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/193/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1933427557256925184" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/191/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1931598063596474368" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/191/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1931598063550337024" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.41</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/184/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1925725054373466112" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/184/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1925725054323134464" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.40</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1920691940551036928" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1920691940475539456" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.39</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/150/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1913461457140322304" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/150/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1913461457094184960" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.38</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1905620202322661376" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/118/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1905651255326281728" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.16.37</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/68/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1896303320889298944" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/68/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-6-x/1896303320847355904" target="_blank">24.6.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
   <div class="history-bar-inner history-bar-outer">
     <div style="margin-top: 5px;">
-      <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:21 UTC
+      <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:19 UTC
     </div>
-    
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-25-3-x/1947224577193021440", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:21 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-24-9-x/1947224575511105536", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:20 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-master/1947224578862354432", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:25:19 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/68/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-master/1896303320948019200", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-02 22:35:28 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/61/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.16-stable-nvidia-gpu-operator-e2e-master/1896219569211576320", "_blank")'>
          <span class="history-square-tooltip">
@@ -915,7 +775,7 @@
     <div class="ocp-version-header">
       OpenShift 4.15
     </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.15-regular">
       <thead>
@@ -925,55 +785,55 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.15.55</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091424571392" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/239/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1946064209657729024" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/239/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1946064209615785984" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.54</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1941740109409816576" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1941740109363679232" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.53</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/209/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1936372460496621568" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/209/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1936372460412735488" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.52</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/193/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1933427557198204928" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1928296519362940928" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1928296519320997888" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.51</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1923595955135844352" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1923595955081318400" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.50</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/162/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1918133410610548736" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/162/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1918133410556022784" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.49</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/144/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1910570483414208512" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/144/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1910570483376459776" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.48</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1905620199709609984" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/107/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1903023446040776704" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/107/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-6-x/1903023445998833664" target="_blank">24.6.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.15.46</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/67/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1896303175753797632" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/67/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-6-x/1896303175711854592" target="_blank">24.6.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
@@ -981,35 +841,21 @@
     <div style="margin-top: 5px;">
       <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:25 UTC
     </div>
-    
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-24-9-x/1947224566283636736", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:25 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-master/1947224570834456576", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:25:25 UTC
          </span>
     </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-25-3-x/1947224568796024832", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:23 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/67/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-master/1896303175799934976", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-02 22:22:26 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/61/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.15-stable-nvidia-gpu-operator-e2e-master/1896219569157050368", "_blank")'>
          <span class="history-square-tooltip">
@@ -1022,7 +868,7 @@
     <div class="ocp-version-header">
       OpenShift 4.14
     </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.14-regular">
       <thead>
@@ -1032,81 +878,67 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.14.54</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091361656832" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1948668610427752448" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-9-x/1948668610385809408" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.14.53</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/218/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1938549364318277632" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/218/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-9-x/1938549364276334592" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.14.52</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/193/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1933427557122707456" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1923595955039375360" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-9-x/1923595954972266496" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.14.51</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/152/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1915578224310489088" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/152/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-9-x/1915627529658437632" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.14.50</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/139/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1908098866461282304" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/139/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-9-x/1908098866410950656" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.14.49</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1905620198027694080" target="_blank">25.3.0</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.14.48</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/95/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-9-x/1900165202712727552" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/95/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-6-x/1900165202528178176" target="_blank">24.6.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
   <div class="history-bar-inner history-bar-outer">
     <div style="margin-top: 5px;">
-      <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:25 UTC
+      <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:23 UTC
     </div>
-    
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-25-3-x/1947224559576944640", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:25 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-master/1947224562332602368", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:25:23 UTC
          </span>
     </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-24-9-x/1947224557056167936", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:16 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/66/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-master/1896303033885659136", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-02 22:19:11 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/61/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.14-stable-nvidia-gpu-operator-e2e-master/1896219569115107328", "_blank")'>
          <span class="history-square-tooltip">
@@ -1119,7 +951,7 @@
     <div class="ocp-version-header">
       OpenShift 4.13
     </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.13-regular">
       <thead>
@@ -1129,25 +961,25 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.13.59</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091315519488" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/230/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-25-3-x/1943587463465275392" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/230/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-24-9-x/1943587461795942400" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.13.58</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/193/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-25-3-x/1933587088859467776" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-25-3-x/1920691940337127424" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/167/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-24-9-x/1920691940257435648" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.13.57</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/64387/rehearse-64387-pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-25-3-x/1917230177318866944" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/64387/rehearse-64387-pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-24-9-x/1917230177276923904" target="_blank">24.9.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
@@ -1155,84 +987,70 @@
     <div style="margin-top: 5px;">
       <strong>Last Bundle Job Date:</strong> 2025-07-21 09:25:24 UTC
     </div>
-    
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1947224552018808832", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:25:24 UTC
          </span>
     </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-24-9-x/1947224547199553536", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:18 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-25-3-x/1947224549502226432", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:25:16 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/181/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1925044893785264128", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-21 06:08:16 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/180/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1924707742639984640", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-20 07:26:08 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/177/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1923595954921934848", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-17 05:51:55 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/175/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1923272309401980928", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-16 08:17:28 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/172/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1922906477828247552", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-15 08:21:38 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/171/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1922545853189328896", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-14 08:18:32 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/168/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1921012693397934080", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-10 02:56:28 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/166/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1919971384860086272", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-05-07 05:42:27 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/164/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.13-stable-nvidia-gpu-operator-e2e-master/1919605699713699840", "_blank")'>
          <span class="history-square-tooltip">
@@ -1245,14 +1063,14 @@
     <div class="ocp-version-header">
       OpenShift 4.12
     </div>
-    
+
   <div class="section-label">Notes</div>
   <div class="note-items">
     <ul>
       <li class="note-item">On Red Hat OpenShift 4.12, starting with the NVIDIA GPU operator v25.3.1, a user must explicitly define a driver image in ClusterPolicy. The default driver image will not work.</li>
     </ul>
   </div>
-    
+
     <div class="section-label">From operator catalog</div>
     <table id="table-4.12-regular">
       <thead>
@@ -1262,40 +1080,40 @@
         </tr>
       </thead>
       <tbody>
-        
+
         <tr>
           <td class="version-cell">4.12.78</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/252/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1949357091265187840" target="_blank">25.3.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1941740109279793152" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-9-x/1941780739993374720" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.12.77</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/66091/rehearse-66091-pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1933946676385419264" target="_blank">25.3.1</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1928329630163406848" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/185/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-9-x/1928296519249694720" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.12.76</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/162/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1918133410425999360" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/162/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-9-x/1918133410165952512" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.12.75</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/138/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1908025751882436608" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/138/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-9-x/1908025751832104960" target="_blank">24.9.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.12.74</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1905620194689028096" target="_blank">25.3.0</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/106/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-9-x/1902667077991272448" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/110/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-6-x/1903750978545389568" target="_blank">24.6.2</a></td>
         </tr>
-        
+
         <tr>
           <td class="version-cell">4.12.73</td>
           <td><a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/64/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-9-x/1896302803752587264" target="_blank">24.9.2</a>, <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/64/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-6-x/1896302803702255616" target="_blank">24.6.2</a></td>
         </tr>
-        
+
       </tbody>
     </table>
-    
+
   <div class="section-label">
     <strong>From main branch (OLM bundle)</strong>
   </div>
@@ -1303,210 +1121,189 @@
     <div style="margin-top: 5px;">
       <strong>Last Bundle Job Date:</strong> 2025-07-25 10:34:53 UTC
     </div>
-    
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/251/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1948668609735692288", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-25 10:34:53 UTC
          </span>
     </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1947224545169510400", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:32:08 UTC
-         </span>
-    </div>
-        
-    <div class='history-square history-aborted'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-24-9-x/1947224544867520512", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: ABORTED | Timestamp: 2025-07-21 09:31:38 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1947224545375031296", "_blank")'>
          <span class="history-square-tooltip">
           Status: ABORTED | Timestamp: 2025-07-21 09:31:09 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1947195545999118336", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-21 08:59:15 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/232/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1944646479201177600", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-14 08:21:07 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/230/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1943587460172746752", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-11 09:54:54 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/229/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1943243541027229696", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-10 11:14:52 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/225/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1942460217757274112", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-08 07:31:35 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/224/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1941740109325930496", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-06 07:28:11 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/222/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1940323052889837568", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-07-02 09:33:28 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/216/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1938123529866186752", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-26 08:04:31 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/214/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1937810689607340032", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-25 11:31:51 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/208/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1935943485735571456", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-20 07:46:05 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/203/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1935236853363904512", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-18 08:54:05 UTC
          </span>
     </div>
-        
-    <div class='history-square history-failure'
-         onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/193/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-25-3-x/1933619943803195392", "_blank")'>
-         <span class="history-square-tooltip">
-          Status: FAILURE | Timestamp: 2025-06-13 21:36:09 UTC
-         </span>
-    </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/189/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1931066803543347200", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-06 20:46:35 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/188/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1930578944088608768", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-05 12:35:11 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/187/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1929101052158676992", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-06-01 10:26:51 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-failure'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/155/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1917088809317568512", "_blank")'>
          <span class="history-square-tooltip">
           Status: FAILURE | Timestamp: 2025-04-29 06:59:15 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-failure'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/153/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1915979125500153856", "_blank")'>
          <span class="history-square-tooltip">
           Status: FAILURE | Timestamp: 2025-04-26 05:19:40 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-failure'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/152/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1915627529616494592", "_blank")'>
          <span class="history-square-tooltip">
           Status: FAILURE | Timestamp: 2025-04-25 06:07:08 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/145/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1910909077345538048", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-12 05:38:36 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/140/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1909788238705332224", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-09 03:28:57 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/136/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1907645082597593088", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-03 05:45:05 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/133/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1907304664265658368", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-02 07:16:02 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/129/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1906897856497717248", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-04-01 03:57:44 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/115/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1905620196362555392", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-28 15:30:52 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-success'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/64/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1896472216904667136", "_blank")'>
          <span class="history-square-tooltip">
           Status: SUCCESS | Timestamp: 2025-03-03 09:52:15 UTC
          </span>
     </div>
-        
+
     <div class='history-square history-aborted'
          onclick='window.open("https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/61/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.12-stable-nvidia-gpu-operator-e2e-master/1896219569073164288", "_blank")'>
          <span class="history-square-tooltip">
@@ -1515,7 +1312,7 @@
     </div>
         </div>
   </div>  <div class="last-updated">
-    Last updated: 2025-07-29 10:55:21 UTC
+    Last updated: 2025-07-30 06:44:05 UTC
   </div>
 </body>
 </html>

--- a/gpu_operator_matrix.json
+++ b/gpu_operator_matrix.json
@@ -2154,31 +2154,5 @@
                 "job_timestamp": 1753785486
             }
         ]
-    },
-    "4.20": {
-        "notes": [],
-        "tests": [
-            {
-                "ocp_full_version": "4.20",
-                "gpu_operator_version": "24-9-x",
-                "test_status": "FAILURE",
-                "prow_job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.20-stable-nvidia-gpu-operator-e2e-24-9-x/1947224608562221056",
-                "job_timestamp": 1753089534
-            },
-            {
-                "ocp_full_version": "4.20",
-                "gpu_operator_version": "25-3-x",
-                "test_status": "FAILURE",
-                "prow_job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.20-stable-nvidia-gpu-operator-e2e-25-3-x/1947224610751647744",
-                "job_timestamp": 1753089529
-            },
-            {
-                "ocp_full_version": "4.20",
-                "gpu_operator_version": "master",
-                "test_status": "FAILURE",
-                "prow_job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_nvidia-ci/243/pull-ci-rh-ecosystem-edge-nvidia-ci-main-4.20-stable-nvidia-gpu-operator-e2e-master/1947224612429369344",
-                "job_timestamp": 1753089529
-            }
-        ]
     }
 }


### PR DESCRIPTION
* Remove 4.20 (added by mistake)
* Re-generate HTML following a fix in bundle reporting #255 