### PR TITLE
Adding compatibility warnings to html dashboard

### DIFF
--- a/workflows/compatibility_warnings.json
+++ b/workflows/compatibility_warnings.json
@@ -1,0 +1,11 @@
+{
+  "warnings": [
+    {
+      "type": "incompatibility",
+      "severity": "warning",
+      "title": "OpenShift 4.18.22",
+      "message": "Currently not compatible with the NVIDIA GPU Operator",
+      "active": true
+    }
+  ]
+}

--- a/workflows/generate_ci_dashboard.py
+++ b/workflows/generate_ci_dashboard.py
@@ -28,6 +28,8 @@ def generate_test_matrix(ocp_data: Dict[str, List[Dict[str, Any]]]) -> str:
       3. Reading the footer template and injecting the last-updated time.
     """
     header_template = load_template("header.html")
+    compatibility_warnings_html = build_compatibility_warnings()
+    header_template = header_template.replace("{compatibility_warnings}", compatibility_warnings_html)
     html_content = header_template
     main_table_template = load_template("main_table.html")
     sorted_ocp_keys = sorted(ocp_data.keys(), reverse=True)
@@ -126,6 +128,39 @@ def build_notes(notes: List[str]) -> str:
     </ul>
   </div>
     """
+
+def load_compatibility_warnings() -> List[Dict[str, Any]]:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    warnings_path = os.path.join(script_dir, "compatibility_warnings.json")
+    
+    with open(warnings_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+        return [w for w in data.get("warnings", []) if w.get("active", True)]
+
+
+def build_compatibility_warnings() -> str:
+    """
+    Build HTML for compatibility warnings and known issues from configuration.
+    """
+    warnings = load_compatibility_warnings()
+    if not warnings:
+        return ""
+    
+    warning_items = ""
+    for warning in warnings:
+        title = warning.get("title", "")
+        message = warning.get("message", "")
+        warning_items += f'<li><strong>{title}:</strong> {message}</li>\n'
+    
+    return f"""
+<div class="compatibility-warnings">
+    <div class="warning-header">Compatibility Notices</div>
+    <ul class="warning-list">
+        {warning_items.strip()}
+    </ul>
+</div>
+    """
+
 
 def build_toc(ocp_keys: List[str]) -> str:
     """

--- a/workflows/templates/header.html
+++ b/workflows/templates/header.html
@@ -11,6 +11,8 @@
 <body>
   <h2>Test Matrix: NVIDIA GPU Operator on Red Hat OpenShift</h2>
 
+  {compatibility_warnings}
+
   <script>
     function sortTable(column, tableId) {
       var table = document.getElementById(tableId);


### PR DESCRIPTION
/cc @empovit
 
---
It will look like that

<img width="1886" height="930" alt="Screenshot From 2025-08-17 14-12-24" src="https://github.com/user-attachments/assets/ce2f5a49-c2cf-412a-9527-65bda24ab736" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI Dashboard now displays a “Compatibility Notices” section showing active warnings.
  * Current notice: OpenShift 4.18.22 is not compatible with the NVIDIA GPU Operator.

* **Chores**
  * Added configuration to manage and surface compatibility warnings in the dashboard template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->