### PR TITLE
Add 4.18.22 to ignored versions because of a bug

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -37,7 +37,7 @@ jobs:
 
         env:
           GH_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OCP_IGNORED_VERSIONS_REGEX: "^4.[0-9]$|^4.1[0-1]$|^4.19.0-rc.0$"
+          OCP_IGNORED_VERSIONS_REGEX: "^4.[0-9]$|^4.1[0-1]$|^4.19.0-rc.0$|^4.18.22$"
           VERSION_FILE_PATH: "workflows/versions.json"
           TEST_TO_TRIGGER_FILE_PATH: "workflows/generated-files/tests_to_trigger.txt"
       - name: Create Pull Request


### PR DESCRIPTION
The GPU operator on 4.18.22 is broken. For now, let's ignore this version to reduce noise until 4.18.23 is out, or the [bug](https://github.com/NVIDIA/gpu-operator/issues/1598) is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated version management to exclude OpenShift version 4.18.22 from processing, reducing noise in update checks and related automation.
  * Improves CI/release workflow stability with no changes to application features or behavior.
  * No user-facing impact; deployments and compatibility remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->