### PR TITLE
Prevent the MicroShift dashboard workflow in forks

### DIFF
--- a/.github/workflows/generate_microshift_dashboard.yaml
+++ b/.github/workflows/generate_microshift_dashboard.yaml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   generate-microshift-dashboard:
+    if: github.event_name != 'schedule' || github.repository == 'rh-ecosystem-edge/nvidia-ci' || vars.MICROSHIFT_DASHBOARD_FLOW_ENABLE_SCHEDULED == 'true'
     runs-on: ubuntu-latest
     env:
       DASHBOARD_OUTPUT_DIR: 'workflows/test_matrix_dashboard/output'


### PR DESCRIPTION
The workflow will still run:
* If triggered manually (`github.event_name != 'schedule'`)
* In the main repository (`github.repository == 'rh-ecosystem-edge/nvidia-ci'`)
* If explicitly enabled in a fork via an env variable (`vars.MICROSHIFT_DASHBOARD_FLOW_ENABLE_SCHEDULED == 'true'`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dashboard-generation workflow conditions: non-scheduled events always trigger the job; scheduled events run only for the designated repository or when explicitly enabled via a configuration variable.
  - Impact: fewer scheduled executions and reduced CI load, with clearer, configurable control over when the workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->