### PR TITLE
Add workflow failure notifications via GitHub Issues

### DIFF
--- a/.github/actions/notify-failure/action.yaml
+++ b/.github/actions/notify-failure/action.yaml
@@ -1,0 +1,29 @@
+name: 'Create Issue on Workflow Failure'
+description: 'Creates a GitHub issue when a workflow fails to notify watchers'
+inputs:
+  github-token:
+    description: 'GitHub token for creating issues'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Create issue on failure
+      if: github.event_name != 'workflow_dispatch'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const workflow_name = context.workflow;
+          const run_url = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+          const title = `Workflow failed: ${workflow_name}`;
+          const body = run_url;
+
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: title,
+            body: body,
+            labels: ['workflow-failure', 'automated']
+          });

--- a/.github/workflows/delete-inactive-branches.yaml
+++ b/.github/workflows/delete-inactive-branches.yaml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   cleanup:
@@ -28,34 +29,34 @@ jobs:
       - name: Delete merged branches created by specified author
         run: |
           echo "Looking for merged PRs created by: $PR_AUTHOR"
-          
+
           echo "Fetching merged pull requests"
           PR_DATA=$(gh pr list --state merged --author "$PR_AUTHOR" --json headRefName,number,author,title --limit 20)
-          
+
           if [ "$PR_DATA" = "[]" ]; then
             echo "No merged PRs found for author: $PR_AUTHOR"
             exit 0
           fi
-          
+
           echo "Extracting branch names"
           BRANCHES=$(echo "$PR_DATA" | jq -r --arg author "$PR_AUTHOR" '.[] | select(.author.login == $author) | .headRefName')
-          
+
           if [ -z "$BRANCHES" ]; then
             echo "No branches found after filtering by author"
             exit 0
           fi
-          
+
           echo "Found branches to potentially delete"
           echo "$BRANCHES"
-          
+
           echo "$BRANCHES" | while read branch; do
             if [ ! -z "$branch" ] && [ "$branch" != "null" ]; then
               echo "Processing branch: $branch"
-          
+
               if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
                 echo "Branch $branch exists remotely"
                 echo "️Deleting branch: $branch"
-          
+
                 if git push origin --delete "$branch"; then
                   echo "Successfully deleted branch: $branch"
                 else
@@ -69,10 +70,15 @@ jobs:
               echo "Skipping empty/null branch name"
             fi
           done
-          
+
           echo "-------------------------"
           echo "Cleanup completed"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: ${{ env.PR_AUTHOR }}
 
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_matrix_page.yaml
+++ b/.github/workflows/generate_matrix_page.yaml
@@ -23,6 +23,7 @@ on:
         type: string
 permissions:
   contents: write
+  issues: write
 jobs:
   generate-matrix:
     if: github.event_name != 'pull_request_target' || github.repository == 'rh-ecosystem-edge/nvidia-ci'
@@ -96,3 +97,10 @@ jobs:
           folder: ${{ env.DASHBOARD_OUTPUT_DIR }}
           clean: false
           force: false
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/generate_microshift_dashboard.yaml
+++ b/.github/workflows/generate_microshift_dashboard.yaml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   generate-microshift-dashboard:
     if: github.event_name != 'schedule' || github.repository == 'rh-ecosystem-edge/nvidia-ci' || vars.MICROSHIFT_DASHBOARD_FLOW_ENABLE_SCHEDULED == 'true'
@@ -77,3 +81,10 @@ jobs:
           folder: ${{ env.DASHBOARD_OUTPUT_DIR }}
           clean: false
           force: false
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -9,6 +9,12 @@ on:
         default: 'main'
         required: false
         type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   ocp-version:
     if: github.event_name != 'schedule' || github.repository == 'rh-ecosystem-edge/nvidia-ci' || vars.VERSION_UPDATE_FLOW_ENABLE_SCHEDULED == 'true'
@@ -58,3 +64,10 @@ jobs:
             ${{ vars.VERSION_UPDATE_FLOW_NOTIFY_USERS }}
           delete-branch: true
           assignees: ${{ vars.VERSION_UPDATE_FLOW_ASSIGNEES }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Create a GitHub issue when workflows fail to notify watchers. Only applies to scheduled and PR-triggered runs, not manual runs. Solves the problem of not being notified about workflow failures in organization repositories.

Add explicit permissions to all workflows following security best practices. See
https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated failure notifications: CI jobs now create an issue when a workflow fails to surface failures and aid triage.

* **Chores**
  * Workflow permissions updated to grant issue creation rights and notify steps added to relevant jobs so failure reports can be posted automatically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->