### PR TITLE
Check GPU operator catalog availability before tracking new versions

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -44,6 +44,7 @@ jobs:
           VERSION_FILE_PATH: "workflows/gpu_operator_versions/versions.json"
           SETTINGS_FILE_PATH: "workflows/gpu_operator_versions/settings.json"
           TEST_TO_TRIGGER_FILE_PATH: "workflows/generated-files/tests_to_trigger.txt"
+          CHECK_CATALOG_AVAILABILITY: "true"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 venv/
 *.pyc
+.cursorrules

--- a/workflows/gpu_operator_dashboard/fetch_ci_data.py
+++ b/workflows/gpu_operator_dashboard/fetch_ci_data.py
@@ -45,7 +45,7 @@ GCS_MAX_RESULTS_PER_REQUEST = 1000
 # Data Fetching & JSON Update Functions
 # =============================================================================
 
-def http_get_json(url: str, params: Dict[str, Any] = None, headers: Dict[str, str] = None) -> Dict[str, Any]:
+def http_get_json(url: str, params: Dict[str, Any] | None = None, headers: Dict[str, str] | None = None) -> Dict[str, Any]:
     """Send an HTTP GET request and return the JSON response."""
     response = requests.get(url, params=params, headers=headers, timeout=30)
     response.raise_for_status()

--- a/workflows/gpu_operator_versions/README.md
+++ b/workflows/gpu_operator_versions/README.md
@@ -7,9 +7,35 @@ This workflow automates the process of checking for new versions of OpenShift an
 The version update automation:
 - Fetches the latest OpenShift release versions from the official API
 - Retrieves NVIDIA GPU Operator versions from container registries
+- Validates GPU operator availability in OpenShift catalogs before triggering tests
 - Updates the version matrix in `versions.json`
 - Generates test commands based on the support matrix in `settings.json`
 - Creates pull requests with version updates
+
+## Catalog Availability Checking
+
+New GPU operator images may not immediately appear in all OpenShift operator catalogs. The workflow verifies catalog availability before tracking new versions.
+
+### Behavior
+
+- New GPU versions available in at least one active OCP catalog are tracked
+- Versions not yet in any catalog are skipped and rechecked on the next run
+- Tests are scheduled for all OCP versions with warnings where the operator is missing
+- OCP version updates proceed independently of GPU catalog status
+
+### Configuration
+
+Environment variable `CHECK_CATALOG_AVAILABILITY`:
+- `false` (default): Disable catalog checking - all new versions are tracked immediately
+- `true`: Enable catalog checking - only versions available in OCP catalogs are tracked
+
+**Note:** The automated CI workflow (`.github/workflows/update-versions.yaml`) sets this to `true` to ensure only catalog-available versions trigger tests.
+
+### Manual Check
+
+```bash
+python -m workflows.gpu_operator_versions.catalog_checker 25.10.1 4.20 4.19
+```
 
 ## Configuration
 

--- a/workflows/gpu_operator_versions/catalog_checker.py
+++ b/workflows/gpu_operator_versions/catalog_checker.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Check if GPU operator versions exist in OpenShift catalog using Red Hat Catalog API.
+"""
+
+import requests
+from workflows.common.utils import logger
+
+# Red Hat Catalog API base URL
+CATALOG_API_BASE = "https://catalog.redhat.com/api/containers/v1"
+
+
+def get_operator_channel(version: str) -> str:
+    """
+    Extract operator channel from version.
+    Channel has 'v' prefix and is major.minor (e.g., "v25.10" from "25.10.1")
+    """
+    parts = version.lstrip('v').split('.')
+    if len(parts) >= 2:
+        return f"v{parts[0]}.{parts[1]}"
+    return f"v{version.lstrip('v')}"
+
+
+def build_catalog_filter(
+    operator_package: str,
+    gpu_versions: set[str],
+    channels: set[str],
+    ocp_versions: set[str]
+) -> str:
+    """Build optimized API filter query for catalog entries."""
+    field_expressions = []
+
+    # Package field (always present)
+    field_expressions.append(f'package=="{operator_package}"')
+
+    # GPU versions field (skip if empty)
+    if gpu_versions:
+        if len(gpu_versions) == 1:
+            field_expressions.append(f'version=="{next(iter(gpu_versions))}"')
+        else:
+            version_ors = ' or '.join(f'version=="{v}"' for v in sorted(gpu_versions))
+            field_expressions.append(f'({version_ors})')
+
+    # Channel names field (skip if empty)
+    if channels:
+        if len(channels) == 1:
+            field_expressions.append(f'channel_name=="{next(iter(channels))}"')
+        else:
+            channel_ors = ' or '.join(f'channel_name=="{c}"' for c in sorted(channels))
+            field_expressions.append(f'({channel_ors})')
+
+    # OCP versions field (skip if empty)
+    if ocp_versions:
+        if len(ocp_versions) == 1:
+            field_expressions.append(f'ocp_version=="{next(iter(ocp_versions))}"')
+        else:
+            ocp_ors = ' or '.join(f'ocp_version=="{ocp}"' for ocp in sorted(ocp_versions))
+            field_expressions.append(f'({ocp_ors})')
+
+    return ' and '.join(field_expressions)
+
+
+def should_stop_pagination(
+    found_combinations: set,
+    expected_combinations: int,
+    fetched_count: int,
+    total_count: int
+) -> bool:
+    """Determine if we should stop paginating through API results."""
+    if len(found_combinations) == expected_combinations:
+        logger.debug(f"Found all {expected_combinations} combinations, stopping pagination")
+        return True
+
+    return fetched_count >= total_count
+
+
+def fetch_catalog_entries(
+    filter_query: str,
+    normalized_gpu_versions: set[str],
+    ocp_versions_set: set[str]
+) -> list[dict]:
+    """Fetch operator catalog entries from Red Hat Catalog API with smart pagination."""
+    url = f"{CATALOG_API_BASE}/operators/bundles"
+    page = 0
+    page_size = 100
+    all_entries = []
+    expected_combinations = len(normalized_gpu_versions) * len(ocp_versions_set)
+
+    while True:
+        params = {"filter": filter_query, "page_size": page_size, "page": page}
+
+        response = requests.get(url, params=params, timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+        entries = data.get('data', [])
+
+        if not entries:
+            break
+
+        all_entries.extend(entries)
+
+        # Check if we've found all needed combinations (early termination)
+        found_combinations = {
+            (e.get('version', '').lstrip('v'), e.get('ocp_version'))
+            for e in all_entries
+            if e.get('version', '').lstrip('v') in normalized_gpu_versions
+            and e.get('ocp_version') in ocp_versions_set
+        }
+
+        fetched_count = len(all_entries)
+
+        if should_stop_pagination(found_combinations, expected_combinations,
+                                 fetched_count, data.get('total', 0)):
+            break
+
+        page += 1
+
+    logger.debug(f"Fetched {len(all_entries)} catalog entries")
+    return all_entries
+
+
+def is_available_in_catalog_entries(
+    catalog_entries: list[dict],
+    gpu_version: str,
+    ocp_version: str
+) -> bool:
+    """
+    Check if specific GPU version is available for specific OCP version in catalog entries.
+
+    Args:
+        catalog_entries: List of catalog entry dicts from Red Hat Catalog API
+        gpu_version: GPU operator version (e.g., "25.10.1")
+        ocp_version: OpenShift version (e.g., "4.20")
+
+    Returns:
+        True if the combination exists, False otherwise
+    """
+    gpu_normalized = gpu_version.lstrip('v')
+    for entry in catalog_entries:
+        if (entry.get('version', '').lstrip('v') == gpu_normalized and
+            entry.get('ocp_version') == ocp_version):
+            return True
+    return False
+
+
+def fetch_gpu_operator_catalog_entries(
+    gpu_versions: list[str],
+    ocp_versions: list[str],
+    operator_package: str = "gpu-operator-certified"
+) -> list[dict]:
+    """
+    Fetch GPU operator catalog entries from Red Hat Catalog for given versions.
+
+    Args:
+        gpu_versions: List of GPU operator versions (e.g., ["25.10.1", "24.6.2"])
+        ocp_versions: List of OpenShift versions (e.g., ["4.20", "4.19"])
+        operator_package: Package name in the catalog
+
+    Returns:
+        List of catalog entry dicts. Use is_available_in_catalog_entries() to check
+        specific combinations.
+
+    Raises:
+        requests.exceptions.RequestException: If API calls fail
+    """
+    # Normalize and prepare data
+    normalized_gpu_versions = set(v.lstrip('v') for v in gpu_versions)
+    channels = set(get_operator_channel(v) for v in gpu_versions)
+    ocp_versions_set = set(ocp_versions)
+
+    logger.info(
+        f"Fetching {operator_package} catalog entries for versions {list(normalized_gpu_versions)} "
+        f"across OCP {', '.join(ocp_versions)}"
+    )
+
+    # Build filter and fetch entries
+    filter_query = build_catalog_filter(operator_package, normalized_gpu_versions,
+                                       channels, ocp_versions_set)
+    entries = fetch_catalog_entries(filter_query, normalized_gpu_versions, ocp_versions_set)
+
+    logger.info(f"Fetched {len(entries)} catalog entries")
+    return entries
+
+
+if __name__ == "__main__":
+    # CLI for informational checking
+    import sys
+
+    if len(sys.argv) < 3:
+        print("Usage: python catalog_checker.py <gpu_version> <ocp_version1> [ocp_version2 ...]")
+        print("Example: python catalog_checker.py 25.10.1 4.20 4.19 4.18 4.17")
+        sys.exit(1)
+
+    gpu_ver = sys.argv[1]
+    ocp_vers = sys.argv[2:]
+
+    catalog_entries = fetch_gpu_operator_catalog_entries([gpu_ver], ocp_vers)
+
+    print(f"\nGPU Operator v{gpu_ver} catalog availability:")
+    for ocp in sorted(ocp_vers, reverse=True):
+        available = is_available_in_catalog_entries(catalog_entries, gpu_ver, ocp)
+        status = "✓ Available" if available else "✗ Not available"
+        print(f"  OpenShift {ocp}: {status}")
+
+
+

--- a/workflows/gpu_operator_versions/nvidia_gpu_operator.py
+++ b/workflows/gpu_operator_versions/nvidia_gpu_operator.py
@@ -71,13 +71,13 @@ def get_sha(settings: Settings) -> str:
                         },
                         timeout=settings.request_timeout_sec)
     req.raise_for_status()
-    
+
     # For OCI index format, the digest is in the Docker-Content-Digest header
     digest = req.headers.get('Docker-Content-Digest', '')
     if not digest:
         logger.error(f'Docker-Content-Digest header not found in response headers: {req.headers}')
         msg = 'Digest not found in manifest response headers'
         raise ValueError(msg)
-    
+
     logger.info(f'Successfully retrieved digest: {digest}')
     return digest

--- a/workflows/gpu_operator_versions/settings.py
+++ b/workflows/gpu_operator_versions/settings.py
@@ -9,11 +9,13 @@ class Settings:
     settings_file_path: str
     request_timeout_sec: int
     support_matrix: dict
+    check_catalog_availability: bool
 
     def __init__(self):
         self.version_file_path = os.getenv("VERSION_FILE_PATH")
         self.tests_to_trigger_file_path = os.getenv("TEST_TO_TRIGGER_FILE_PATH")
         self.request_timeout_sec = int(os.getenv("REQUEST_TIMEOUT_SECONDS", 30))
+        self.check_catalog_availability = os.getenv("CHECK_CATALOG_AVAILABILITY", "false").lower() == "true"
 
         # Settings file can be specified via env var or defaults to settings.json in same directory
         self.settings_file_path = os.getenv(

--- a/workflows/gpu_operator_versions/test_catalog_checker.py
+++ b/workflows/gpu_operator_versions/test_catalog_checker.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Test script for catalog checker functionality.
+Can be run locally to verify catalog checking works.
+"""
+
+import sys
+from workflows.gpu_operator_versions.catalog_checker import (
+    fetch_gpu_operator_catalog_entries,
+    is_available_in_catalog_entries
+)
+
+
+def test_single_version_multiple_ocp():
+    """Test checking a single GPU operator version across multiple OCP versions."""
+    print("=" * 70)
+    print("Test 1: Single GPU operator version across multiple OCP versions")
+    print("=" * 70)
+
+    ocp_versions = ["4.20", "4.19", "4.18"]
+    gpu_version = "24.6.2"
+    catalog_entries = fetch_gpu_operator_catalog_entries(
+        gpu_versions=[gpu_version],
+        ocp_versions=ocp_versions
+    )
+
+    print("\nResults:")
+    available_count = 0
+    for ocp in sorted(ocp_versions, reverse=True):
+        available = is_available_in_catalog_entries(catalog_entries, gpu_version, ocp)
+        status = "✓" if available else "✗"
+        print(f"  OCP {ocp}: {status}")
+        if available:
+            available_count += 1
+
+    total_count = len(ocp_versions)
+    passed = available_count == total_count
+    print(f"\nResult: {'PASS ✓' if passed else f'PARTIAL ({available_count}/{total_count})'}")
+    return passed
+
+
+def test_multiple_versions_multiple_ocp():
+    """Test checking multiple GPU operator versions across multiple OCP versions."""
+    print("\n" + "=" * 70)
+    print("Test 2: Multiple GPU operator versions across multiple OCP versions")
+    print("=" * 70)
+
+    gpu_versions = ["25.10.1", "24.6.2"]
+    ocp_versions = ["4.20", "4.19"]
+    catalog_entries = fetch_gpu_operator_catalog_entries(
+        gpu_versions=gpu_versions,
+        ocp_versions=ocp_versions
+    )
+
+    print("\nResults:")
+    all_available = True
+    for gpu_ver in sorted(gpu_versions):
+        print(f"  GPU operator {gpu_ver}:")
+        for ocp in sorted(ocp_versions, reverse=True):
+            available = is_available_in_catalog_entries(catalog_entries, gpu_ver, ocp)
+            status = "✓" if available else "✗"
+            print(f"    OCP {ocp}: {status}")
+            if not available:
+                all_available = False
+
+    print(f"\nResult: {'PASS ✓' if all_available else 'PARTIAL'}")
+    return all_available
+
+
+def test_nonexistent_version():
+    """Test with a version that doesn't exist."""
+    print("\n" + "=" * 70)
+    print("Test 3: Non-existent GPU operator version")
+    print("=" * 70)
+
+    gpu_version = "99.99.99"
+    ocp_version = "4.20"
+    catalog_entries = fetch_gpu_operator_catalog_entries(
+        gpu_versions=[gpu_version],
+        ocp_versions=[ocp_version]
+    )
+
+    found = is_available_in_catalog_entries(catalog_entries, gpu_version, ocp_version)
+
+    print(f"\nResult: {'FAIL ✗ (should not exist)' if found else 'PASS ✓ (correctly not found)'}")
+    return not found
+
+
+def test_mixed_availability():
+    """Test with versions that may have different availability across OCP versions."""
+    print("\n" + "=" * 70)
+    print("Test 4: GPU operator availability across wide OCP range")
+    print("=" * 70)
+
+    gpu_version = "25.10.1"
+    ocp_versions = ["4.20", "4.19", "4.16", "4.13"]
+    catalog_entries = fetch_gpu_operator_catalog_entries(
+        gpu_versions=[gpu_version],
+        ocp_versions=ocp_versions
+    )
+
+    print("\nResults:")
+    for ocp in sorted(ocp_versions, reverse=True):
+        available = is_available_in_catalog_entries(catalog_entries, gpu_version, ocp)
+        status = "✓" if available else "✗"
+        print(f"  OCP {ocp}: {status}")
+
+    # This test is informational - we expect it might not be in older versions
+    print("\nResult: INFORMATIONAL (showing version distribution)")
+    return True
+
+
+def main():
+    print("\n" + "=" * 70)
+    print("GPU Operator Catalog Checker - Test Suite")
+    print("=" * 70)
+    print("\nNOTE: These tests require:")
+    print("  1. Internet connection")
+    print("  2. Access to catalog.redhat.com API (public, no auth required)")
+    print("  3. Tests complete in ~5-10 seconds")
+    print()
+
+    tests = [
+        ("Single version, multiple OCP", test_single_version_multiple_ocp),
+        ("Multiple versions, multiple OCP", test_multiple_versions_multiple_ocp),
+        ("Non-existent version", test_nonexistent_version),
+        ("Wide OCP range", test_mixed_availability),
+    ]
+
+    results = []
+    for name, test_func in tests:
+        try:
+            passed = test_func()
+            results.append((name, passed, None))
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            print(f"\n✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+            results.append((name, False, str(e)))
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("Test Summary")
+    print("=" * 70)
+
+    passed_count = sum(1 for _, passed, _ in results if passed)
+    total_count = len(results)
+
+    for name, passed, error in results:
+        status = "✓ PASS" if passed else "✗ FAIL"
+        print(f"{status}: {name}")
+        if error:
+            print(f"  Error: {error}")
+
+    print(f"\nTotal: {passed_count}/{total_count} tests passed")
+
+    return 0 if passed_count == total_count else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+

--- a/workflows/gpu_operator_versions/tests/test_update_versions.py
+++ b/workflows/gpu_operator_versions/tests/test_update_versions.py
@@ -1,7 +1,12 @@
 import copy
 import unittest
+from unittest.mock import patch
 
-from workflows.gpu_operator_versions.update_versions import calculate_diffs, create_tests_matrix
+from workflows.gpu_operator_versions.update_versions import (
+    calculate_diffs,
+    create_tests_matrix,
+    filter_new_gpu_versions_by_catalog
+)
 
 base_versions = {
     'gpu-main-latest': 'A',
@@ -30,68 +35,68 @@ class TestCalculateDiffs(unittest.TestCase):
     def test_bundle_key_created(self):
         old_versions = {}
         new_versions = {'gpu-main-latest': 'XYZ'}
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'gpu-main-latest': 'XYZ'})
 
     def test_bundle_changed(self):
         old_versions = base_versions
         new_versions = copy.deepcopy(old_versions)
         new_versions['gpu-main-latest'] = 'B'
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'gpu-main-latest': 'B'})
 
     def test_gpu_versions_key_created(self):
         old_versions = {}
         new_versions = {'gpu-operator': {'25.1': '25.1.1'}}
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'gpu-operator': {'25.1': '25.1.1'}})
 
     def test_gpu_version_changed(self):
         old_versions = base_versions
         new_versions = copy.deepcopy(old_versions)
         new_versions['gpu-operator']['25.1'] = '25.1.1'
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'gpu-operator': {'25.1': '25.1.1'}})
 
     def test_gpu_version_added(self):
         old_versions = base_versions
         new_versions = copy.deepcopy(old_versions)
         new_versions['gpu-operator']['25.3'] = '25.3.0'
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'gpu-operator': {'25.3': '25.3.0'}})
 
     def test_gpu_version_removed(self):
         old_versions = base_versions
         new_versions = copy.deepcopy(old_versions)
         del new_versions['gpu-operator']['25.2']
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {})
 
     def test_ocp_version_key_created(self):
         old_versions = {}
         new_versions = {'ocp': {'4.12': '4.12.2'}}
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'ocp': {'4.12': '4.12.2'}})
 
     def test_ocp_version_changed(self):
         old_versions = base_versions
         new_versions = copy.deepcopy(old_versions)
         new_versions['ocp']['4.12'] = '4.12.2'
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'ocp': {'4.12': '4.12.2'}})
 
     def test_ocp_version_added(self):
         old_versions = base_versions
         new_versions = copy.deepcopy(old_versions)
         new_versions['ocp']['4.15'] = '4.15.0'
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {'ocp': {'4.15': '4.15.0'}})
 
     def test_ocp_version_removed(self):
         old_versions = base_versions
         new_versions = copy.deepcopy(old_versions)
         del new_versions['ocp']['4.14']
-        diff = calculate_diffs(old_versions, new_versions)
+        diff, _ = calculate_diffs(old_versions, new_versions)
         self.assertEqual(diff, {})
 
 
@@ -101,7 +106,7 @@ class TestCreateTestsMatrix(unittest.TestCase):
         diff = {'gpu-main-latest': 'B'}
         tests = create_tests_matrix(
             diff, ['4.14', '4.10', '4.11', '4.13'], ['21.3', '22.3'], default_support_matrix)
-        self.assertEqual(tests, {('4.14', 'master'), ('4.10', 'master')})
+        self.assertEqual(tests, {('4.14', 'master', None), ('4.10', 'master', None)})
 
     def test_bundle_changed_with_maintenance(self):
         """Master should only test with active OCP versions."""
@@ -116,7 +121,7 @@ class TestCreateTestsMatrix(unittest.TestCase):
         tests = create_tests_matrix(
             diff, ['4.14', '4.10', '4.11', '4.13'], ['21.3', '22.3'], support_matrix)
         # Should only test with active versions: 4.14 (newest), 4.11 (oldest active)
-        self.assertEqual(tests, {('4.14', 'master'), ('4.11', 'master')})
+        self.assertEqual(tests, {('4.14', 'master', None), ('4.11', 'master', None)})
 
     def test_gpu_version_changed_existing(self):
         """When existing GPU version is updated, test only with active OCP versions."""
@@ -124,7 +129,7 @@ class TestCreateTestsMatrix(unittest.TestCase):
         tests = create_tests_matrix(
             diff, ['4.11', '4.13'], ['24.3', '25.1'], default_support_matrix)
         # Should test with both OCP versions since both are active and use latest 2 GPU versions
-        self.assertEqual(tests, {('4.11', '25.1'), ('4.13', '25.1')})
+        self.assertEqual(tests, {('4.11', '25.1', None), ('4.13', '25.1', None)})
 
     def test_gpu_version_changed_with_maintenance(self):
         """When existing GPU version is updated, maintenance OCP versions should NOT test it."""
@@ -138,7 +143,7 @@ class TestCreateTestsMatrix(unittest.TestCase):
         tests = create_tests_matrix(
             diff, ['4.11', '4.13'], ['25.1', '25.3'], support_matrix)
         # Should only test with active OCP (4.13), NOT maintenance (4.11) even though 25.1 is pinned
-        self.assertEqual(tests, {('4.13', '25.1')})
+        self.assertEqual(tests, {('4.13', '25.1', None)})
 
     def test_gpu_version_added_new(self):
         """When new GPU version is added, test with active OCP versions only."""
@@ -152,14 +157,14 @@ class TestCreateTestsMatrix(unittest.TestCase):
         tests = create_tests_matrix(
             diff, ['4.11', '4.13'], ['25.1', '25.3'], support_matrix)
         # Should only test with active OCP (4.13), not maintenance (4.11)
-        self.assertEqual(tests, {('4.13', '25.3')})
+        self.assertEqual(tests, {('4.13', '25.3', None)})
 
     def test_ocp_version_changed_active(self):
         """When active OCP version gets patch, test with latest 2 GPU versions."""
         diff = {'ocp': {'4.12': '4.12.2'}}
         tests = create_tests_matrix(
             diff, ['4.12', '4.13'], ['24.4', '25.3'], default_support_matrix)
-        self.assertEqual(tests, {('4.12', '24.4'), ('4.12', '25.3')})
+        self.assertEqual(tests, {('4.12', '24.4', None), ('4.12', '25.3', None)})
 
     def test_ocp_version_changed_maintenance(self):
         """When maintenance OCP version gets patch, test only with pinned GPU."""
@@ -173,7 +178,7 @@ class TestCreateTestsMatrix(unittest.TestCase):
         tests = create_tests_matrix(
             diff, ['4.12', '4.13'], ['24.4', '25.3'], support_matrix)
         # Should only test with pinned version
-        self.assertEqual(tests, {('4.12', '25.3')})
+        self.assertEqual(tests, {('4.12', '25.3', None)})
 
     def test_ocp_version_changed_maintenance_multiple_pins(self):
         """Test maintenance OCP with multiple pinned GPU versions."""
@@ -187,20 +192,192 @@ class TestCreateTestsMatrix(unittest.TestCase):
         tests = create_tests_matrix(
             diff, ['4.12', '4.13'], ['24.4', '25.3'], support_matrix)
         # Should test with both pinned versions
-        self.assertEqual(tests, {('4.12', '24.4'), ('4.12', '25.3')})
+        self.assertEqual(tests, {('4.12', '24.4', None), ('4.12', '25.3', None)})
 
     def test_ocp_version_added_new(self):
         """New OCP version defaults to active, tests with latest 2 GPU."""
         diff = {'ocp': {'4.15': '4.15.0'}}
         tests = create_tests_matrix(
             diff, ['4.12', '4.13', '4.15'], ['24.4', '25.3'], default_support_matrix)
-        self.assertEqual(tests, {('4.15', '24.4'), ('4.15', '25.3')})
+        self.assertEqual(tests, {('4.15', '24.4', None), ('4.15', '25.3', None)})
 
     def test_no_changes(self):
         diff = {}
         tests = create_tests_matrix(
             diff, ['4.11', '4.13'], ['25.1', '25.3'], default_support_matrix)
         self.assertEqual(tests, set())
+
+
+class TestFilterNewGpuVersionsByCatalog(unittest.TestCase):
+    """Tests for catalog availability filtering."""
+
+    def test_filters_out_unavailable_in_catalog(self):
+        """Versions not in any catalog should be excluded."""
+        gpu_diffs = {
+            '25.3': '25.3.1',  # Not in catalog
+            '25.2': '25.2.8',  # In catalog
+        }
+        ocp_versions = {'4.19': '4.19.0', '4.20': '4.20.0'}
+        support_matrix = default_support_matrix
+
+        # Mock catalog entries that show only 25.2 is available
+        mock_entries = [
+            {'version': '25.2.8', 'ocp_version': '4.19'},
+            {'version': '25.2.8', 'ocp_version': '4.20'},
+        ]
+
+        with patch('workflows.gpu_operator_versions.update_versions.fetch_gpu_operator_catalog_entries',
+                  return_value=mock_entries):
+            filtered, _ = filter_new_gpu_versions_by_catalog(
+                gpu_diffs, ocp_versions, support_matrix
+            )
+
+        # Only 25.2 should be included (available in catalog)
+        self.assertEqual(filtered, {'25.2': '25.2.8'})
+
+    def test_includes_all_versions_in_catalog(self):
+        """All versions in catalog should be included regardless of minor version."""
+        gpu_diffs = {
+            '24.1': '24.1.5',  # Older version but in catalog
+            '25.3': '25.3.1',  # Newer version and in catalog
+            '25.2': '25.2.8',  # Another version in catalog
+        }
+        ocp_versions = {'4.19': '4.19.0', '4.20': '4.20.0'}
+        support_matrix = default_support_matrix
+
+        # Mock catalog entries showing all versions are available
+        mock_entries = [
+            {'version': '24.1.5', 'ocp_version': '4.19'},
+            {'version': '25.3.1', 'ocp_version': '4.19'},
+            {'version': '25.2.8', 'ocp_version': '4.20'},
+        ]
+
+        with patch('workflows.gpu_operator_versions.update_versions.fetch_gpu_operator_catalog_entries',
+                  return_value=mock_entries):
+            filtered, _ = filter_new_gpu_versions_by_catalog(
+                gpu_diffs, ocp_versions, support_matrix
+            )
+
+        # All versions in catalog should be included
+        self.assertEqual(filtered, {
+            '24.1': '24.1.5',
+            '25.3': '25.3.1',
+            '25.2': '25.2.8',
+        })
+
+    def test_excludes_all_when_not_in_catalog(self):
+        """Versions not in any catalog should all be excluded."""
+        gpu_diffs = {
+            '25.3': '25.3.1',  # Not in catalog
+            '25.2': '25.2.8',  # Not in catalog
+        }
+        ocp_versions = {'4.19': '4.19.0', '4.20': '4.20.0'}
+        support_matrix = default_support_matrix
+
+        # Mock empty catalog entries
+        mock_entries = []
+
+        with patch('workflows.gpu_operator_versions.update_versions.fetch_gpu_operator_catalog_entries',
+                  return_value=mock_entries):
+            filtered, _ = filter_new_gpu_versions_by_catalog(
+                gpu_diffs, ocp_versions, support_matrix
+            )
+
+        # Nothing should be included
+        self.assertEqual(filtered, {})
+
+    def test_available_in_at_least_one_ocp(self):
+        """Version available in at least one OCP catalog should be included."""
+        gpu_diffs = {
+            '25.3': '25.3.1',
+        }
+        ocp_versions = {'4.19': '4.19.0', '4.20': '4.20.0'}
+        support_matrix = default_support_matrix
+
+        # Mock catalog showing version only in 4.20, not 4.19
+        mock_entries = [
+            {'version': '25.3.1', 'ocp_version': '4.20'},
+        ]
+
+        with patch('workflows.gpu_operator_versions.update_versions.fetch_gpu_operator_catalog_entries',
+                  return_value=mock_entries):
+            filtered, _ = filter_new_gpu_versions_by_catalog(
+                gpu_diffs, ocp_versions, support_matrix
+            )
+
+        # Should be included since it's in at least one catalog
+        self.assertEqual(filtered, {'25.3': '25.3.1'})
+
+    def test_empty_gpu_diffs_returns_empty(self):
+        """Empty diffs should return empty without calling catalog API."""
+        with patch('workflows.gpu_operator_versions.update_versions.fetch_gpu_operator_catalog_entries') as mock_fetch:
+            filtered, entries = filter_new_gpu_versions_by_catalog(
+                {}, {'4.19': '4.19.0'}, default_support_matrix
+            )
+        self.assertEqual(filtered, {})
+        self.assertEqual(entries, [])
+        mock_fetch.assert_not_called()
+
+    def test_no_active_ocp_returns_all_gpu_diffs(self):
+        """When no active OCP versions exist, all GPU diffs should be kept."""
+        gpu_diffs = {
+            '25.3': '25.3.1',
+            '25.2': '25.2.8',
+        }
+        ocp_versions = {'4.19': '4.19.0'}
+        # Support matrix with only maintenance (no active) OCP versions
+        support_matrix_no_active = {
+            "openshift_support": {
+                '4.19': {'status': 'maintenance', 'pinned_gpu_operator': '24.6'}
+            }
+        }
+
+        with patch('workflows.gpu_operator_versions.update_versions.fetch_gpu_operator_catalog_entries') as mock_fetch:
+            filtered, entries = filter_new_gpu_versions_by_catalog(
+                gpu_diffs, ocp_versions, support_matrix_no_active
+            )
+
+        # All GPU diffs should be kept when there are no active OCPs
+        self.assertEqual(filtered, gpu_diffs)
+        self.assertEqual(entries, [])
+        # Catalog API should not be called
+        mock_fetch.assert_not_called()
+
+    def test_catalog_filtering_in_calculate_diffs(self):
+        """Catalog filtering should remove unavailable GPU versions from diffs."""
+        old_versions = {
+            'gpu-operator': {
+                '25.1': '25.1.0',
+                '25.2': '25.2.0'
+            }
+        }
+        new_versions = {
+            'gpu-operator': {
+                '25.1': '25.1.0',
+                '25.2': '25.2.0',
+                '25.3': '25.3.1',  # New version, but not in catalog
+                '25.4': '25.4.0',  # New version, in catalog
+            }
+        }
+        ocp_versions = {'4.19': '4.19.0', '4.20': '4.20.0'}
+        support_matrix = default_support_matrix
+
+        # Mock catalog with only 25.4 available
+        mock_entries = [
+            {'version': '25.4.0', 'ocp_version': '4.19'},
+            {'version': '25.4.0', 'ocp_version': '4.20'},
+        ]
+
+        with patch('workflows.gpu_operator_versions.update_versions.fetch_gpu_operator_catalog_entries',
+                  return_value=mock_entries):
+            diffs, _ = calculate_diffs(
+                old_versions, new_versions, ocp_versions, support_matrix, check_catalog=True
+            )
+
+        # Only 25.4 should be in diffs (25.3 filtered out due to catalog unavailability)
+        self.assertIn('gpu-operator', diffs)
+        self.assertEqual(diffs['gpu-operator'], {'25.4': '25.4.0'})
+        self.assertNotIn('25.3', diffs['gpu-operator'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
New GPU operator versions are only added to versions.json if they're available in at least one active OCP catalog. If not available yet, the version stays untracked and the workflow retries on the next run.

- Prevents committing untestable GPU versions
- OCP updates proceed normally regardless of GPU catalog status
- Warnings generated for OCP versions missing the operator
- Tests scheduled for all OCP versions (even with warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional catalog-availability check before scheduling GPU operator tests, controllable via the CHECK_CATALOG_AVAILABILITY env flag (enabled in CI).

* **Documentation**
  * Expanded workflow documentation on catalog checking behavior, configuration options, and manual check examples.

* **Tests**
  * Added a catalog checker test suite and a runnable checker to validate availability filtering and scenarios.

* **Chores**
  * Updated ignore rules to exclude .cursorrules files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->