### PR TITLE
NVIDIA-871 Add timeslicing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 venv/
 *.pyc
 .cursorrules
+scripts/gpu-operator-must-gather.sh
+scripts/nfd-must-gather.sh

--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ in the last execution of either steps 1 or 2
 $ export NVIDIAGPU_CLEANUP=true
 ```
 
+### Testing Time-Slicing with GPU Operator
+
+To test GPU time-slicing, deploy the GPU Operator first, then run the time-slicing tests.
+The test creates a device plugin ConfigMap with time-slicing configuration, deploys a
+ClusterPolicy referencing it, and validates that multiple CUDA workloads run concurrently
+on a single time-sliced GPU.
+
+#### Steps to run time-slicing tests:
+
+1. Deploy the GPU Operator with cleanup disabled (same as MPS step 1 above)
+2. Run the time-slicing tests:
+```bash
+$ export TEST_FEATURES="timeslicing"
+$ export TEST_LABELS='nvidia-ci,timeslicing'
+$ make run-tests
+```
+
 ### Examples of Testing GPU Operator end-to-end
 
 Example running the end-to-end GPU Operator test case:

--- a/internal/timeslicing/timeslicing.go
+++ b/internal/timeslicing/timeslicing.go
@@ -1,0 +1,162 @@
+package timeslicing
+
+import (
+	"fmt"
+
+	nvidiagpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
+	"github.com/golang/glog"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/gpuparams"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/configmap"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/nvidiagpu"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/olm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// CreateDevicePluginConfigMap creates a ConfigMap with the device plugin configuration for time-slicing.
+func CreateDevicePluginConfigMap(apiClient *clients.Settings, replicas int,
+	configMapName, configMapNamespace string, renameByDefault bool) (*configmap.Builder, error) {
+	config := map[string]any{
+		"version": "v1",
+		"sharing": map[string]any{
+			"timeSlicing": map[string]any{
+				"renameByDefault":            renameByDefault,
+				"failRequestsGreaterThanOne": false,
+				"resources": []map[string]any{
+					{
+						"name":     "nvidia.com/gpu",
+						"replicas": replicas,
+					},
+				},
+			},
+		},
+	}
+
+	yamlData, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal time-slicing config: %w", err)
+	}
+
+	devicePluginConfig := map[string]string{
+		"plugin-config.yaml": string(yamlData),
+	}
+
+	configMapBuilder := configmap.NewBuilder(apiClient, configMapName, configMapNamespace)
+	configMapBuilderWithData := configMapBuilder.WithData(devicePluginConfig)
+
+	createdConfigMapBuilder, err := configMapBuilderWithData.Create()
+	if err != nil {
+		glog.V(gpuparams.GpuLogLevel).Infof(
+			"error creating time-slicing ConfigMap %s in namespace %s: %v",
+			configMapName, configMapNamespace, err)
+
+		return nil, err
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof(
+		"Created time-slicing ConfigMap %s in namespace %s",
+		createdConfigMapBuilder.Object.Name, createdConfigMapBuilder.Object.Namespace)
+
+	return createdConfigMapBuilder, nil
+}
+
+// CreateClusterPolicyFromCSV creates a new ClusterPolicy from the CSV ALM example
+// with device plugin configuration referencing the time-slicing ConfigMap.
+func CreateClusterPolicyFromCSV(apiClient *clients.Settings,
+	gpuOperatorNamespace, clusterPolicyName string) (*nvidiagpu.Builder, error) {
+	glog.V(gpuparams.GpuLogLevel).Infof("Creating ClusterPolicy %s from CSV ALM example with time-slicing config",
+		clusterPolicyName)
+
+	csvList, err := olm.ListClusterServiceVersion(apiClient, gpuOperatorNamespace, metav1.ListOptions{
+		LabelSelector: "operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CSV: %w", err)
+	}
+
+	if len(csvList) == 0 {
+		return nil, fmt.Errorf("no matching CSV found")
+	}
+
+	almExample, ok := csvList[0].Object.Annotations["alm-examples"]
+	if !ok {
+		return nil, fmt.Errorf("CSV does not contain alm-examples annotation")
+	}
+
+	clusterPolicy := nvidiagpu.NewBuilderFromObjectString(apiClient, almExample)
+	clusterPolicy.Definition.Name = clusterPolicyName
+
+	enabled := true
+	clusterPolicy.Definition.Spec.DevicePlugin.Enabled = &enabled
+
+	if clusterPolicy.Definition.Spec.DevicePlugin.Config == nil {
+		clusterPolicy.Definition.Spec.DevicePlugin.Config = &nvidiagpuv1.DevicePluginConfig{}
+	}
+
+	clusterPolicy.Definition.Spec.DevicePlugin.Config.Name = "plugin-config"
+	clusterPolicy.Definition.Spec.DevicePlugin.Config.Default = "plugin-config.yaml"
+
+	createdPolicy, err := clusterPolicy.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ClusterPolicy: %w", err)
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Successfully created ClusterPolicy %s with time-slicing config",
+		clusterPolicyName)
+
+	return createdPolicy, nil
+}
+
+// CreateTimeSlicingTestPod returns a Pod spec configured for time-slicing validation.
+func CreateTimeSlicingTestPod(podName, podNamespace, image string) *corev1.Pod {
+	isTrue := true
+	isFalse := false
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Labels: map[string]string{
+				"app": "timeslicing-test-app",
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   &isTrue,
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "nvidia.com/gpu",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "cuda-vectoradd",
+					Image: image,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &isFalse,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				"nvidia.com/gpu.present":         "true",
+				"node-role.kubernetes.io/worker": "",
+			},
+		},
+	}
+}

--- a/internal/timeslicing/timeslicing.go
+++ b/internal/timeslicing/timeslicing.go
@@ -2,6 +2,7 @@ package timeslicing
 
 import (
 	"fmt"
+	"strings"
 
 	nvidiagpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 	"github.com/golang/glog"
@@ -19,6 +20,18 @@ import (
 // CreateDevicePluginConfigMap creates a ConfigMap with the device plugin configuration for time-slicing.
 func CreateDevicePluginConfigMap(apiClient *clients.Settings, replicas int,
 	configMapName, configMapNamespace string, renameByDefault bool) (*configmap.Builder, error) {
+	if replicas <= 0 {
+		return nil, fmt.Errorf("replicas must be greater than 0, got %d", replicas)
+	}
+
+	if strings.TrimSpace(configMapName) == "" {
+		return nil, fmt.Errorf("configMapName must not be empty")
+	}
+
+	if strings.TrimSpace(configMapNamespace) == "" {
+		return nil, fmt.Errorf("configMapNamespace must not be empty")
+	}
+
 	config := map[string]any{
 		"version": "v1",
 		"sharing": map[string]any{
@@ -66,7 +79,7 @@ func CreateDevicePluginConfigMap(apiClient *clients.Settings, replicas int,
 // CreateClusterPolicyFromCSV creates a new ClusterPolicy from the CSV ALM example
 // with device plugin configuration referencing the time-slicing ConfigMap.
 func CreateClusterPolicyFromCSV(apiClient *clients.Settings,
-	gpuOperatorNamespace, clusterPolicyName string) (*nvidiagpu.Builder, error) {
+	gpuOperatorNamespace, clusterPolicyName, configMapName string) (*nvidiagpu.Builder, error) {
 	glog.V(gpuparams.GpuLogLevel).Infof("Creating ClusterPolicy %s from CSV ALM example with time-slicing config",
 		clusterPolicyName)
 
@@ -96,7 +109,7 @@ func CreateClusterPolicyFromCSV(apiClient *clients.Settings,
 		clusterPolicy.Definition.Spec.DevicePlugin.Config = &nvidiagpuv1.DevicePluginConfig{}
 	}
 
-	clusterPolicy.Definition.Spec.DevicePlugin.Config.Name = "plugin-config"
+	clusterPolicy.Definition.Spec.DevicePlugin.Config.Name = configMapName
 	clusterPolicy.Definition.Spec.DevicePlugin.Config.Default = "plugin-config.yaml"
 
 	createdPolicy, err := clusterPolicy.Create()
@@ -112,6 +125,13 @@ func CreateClusterPolicyFromCSV(apiClient *clients.Settings,
 
 // CreateTimeSlicingTestPod returns a Pod spec configured for time-slicing validation.
 func CreateTimeSlicingTestPod(podName, podNamespace, image string) *corev1.Pod {
+	if strings.TrimSpace(podName) == "" || strings.TrimSpace(podNamespace) == "" || strings.TrimSpace(image) == "" {
+		glog.Errorf("CreateTimeSlicingTestPod: podName, podNamespace, and image must not be empty "+
+			"(got podName=%q, podNamespace=%q, image=%q)", podName, podNamespace, image)
+
+		return nil
+	}
+
 	isTrue := true
 	isFalse := false
 

--- a/internal/tsparams/timeslicingvars.go
+++ b/internal/tsparams/timeslicingvars.go
@@ -1,0 +1,24 @@
+package tsparams
+
+import (
+	nvidiagpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
+	"github.com/openshift-kni/k8sreporter"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/gpuparams"
+)
+
+var (
+	// TimeSlicingLabels represents the range of labels that can be used for test cases selection.
+	TimeSlicingLabels = append(gpuparams.Labels, LabelSuite)
+
+	// TimeSlicingReporterNamespacesToDump tells to the reporter from where to collect logs.
+	TimeSlicingReporterNamespacesToDump = map[string]string{
+		"openshift-nfd":       "nfd-operator",
+		"nvidia-gpu-operator": "gpu-operator",
+		"test-timeslicing":    "test-timeslicing",
+	}
+
+	// TimeSlicingReporterCRDsToDump tells to the reporter what CRs to dump.
+	TimeSlicingReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &nvidiagpuv1.ClusterPolicyList{}},
+	}
+)

--- a/tests/timeslicing/timeslicing_suite_test.go
+++ b/tests/timeslicing/timeslicing_suite_test.go
@@ -1,0 +1,31 @@
+package timeslicing
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/reporter"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/tsparams"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestTimeSlicing(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = inittools.GeneralConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TimeSlicing", Label("nvidia-ci", "timeslicing"), reporterConfig)
+}
+
+var _ = JustAfterEach(func() {
+	specReport := CurrentSpecReport()
+	reporter.ReportIfFailed(
+		specReport, currentFile, tsparams.TimeSlicingReporterNamespacesToDump,
+		tsparams.TimeSlicingReporterCRDsToDump, clients.SetScheme)
+})

--- a/tests/timeslicing/timeslicing_test.go
+++ b/tests/timeslicing/timeslicing_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools"
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/timeslicing"
 	"github.com/rh-ecosystem-edge/nvidia-ci/internal/tsparams"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/wait"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/configmap"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/namespace"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/nodes"
@@ -42,15 +43,14 @@ var _ = Describe("TimeSlicing", Ordered, Label(tsparams.LabelSuite), func() {
 	BeforeAll(func() {
 		glog.V(gpuparams.GpuLogLevel).Info("Starting TimeSlicing test suite")
 
-		if tmpClusterPolicyBuilder, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName); err == nil {
+		tmpClusterPolicyBuilder, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
+		if err == nil {
 			if _, err := tmpClusterPolicyBuilder.Get(); err == nil {
 				if _, err := tmpClusterPolicyBuilder.Delete(); err != nil {
 					glog.Errorf("Error deleting cluster policy: %v", err)
 				} else {
 					EnsureOnlyOperatorIsRunning()
 				}
-			} else {
-				glog.Error("didn't find cluster policy")
 			}
 		}
 
@@ -107,11 +107,15 @@ var _ = Describe("TimeSlicing", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By("Creating ClusterPolicy from CSV with time-slicing device plugin config")
 			clusterPolicy, err = timeslicing.CreateClusterPolicyFromCSV(
-				inittools.APIClient, GPUOperatorNamespace, nvidiagpu.ClusterPolicyName)
+				inittools.APIClient, GPUOperatorNamespace, nvidiagpu.ClusterPolicyName,
+				DevicePluginConfigMapName)
 			Expect(err).ToNot(HaveOccurred(), "error creating cluster policy: %v", err)
 
-			By("Waiting for all GPU operator pods to be running")
-			EnsureAllGpuPodsAreRunning()
+			By(fmt.Sprintf("Waiting up to %s for ClusterPolicy to be ready",
+				nvidiagpu.ClusterPolicyReadyTimeout))
+			err = wait.ClusterPolicyReady(inittools.APIClient, nvidiagpu.ClusterPolicyName,
+				nvidiagpu.ClusterPolicyReadyCheckInterval, nvidiagpu.ClusterPolicyReadyTimeout)
+			Expect(err).ToNot(HaveOccurred(), "error waiting for ClusterPolicy to be ready: %v", err)
 
 			By("Verifying node labels reflect time-slicing configuration")
 			clusterNodes, err := nodes.List(inittools.APIClient)
@@ -199,38 +203,6 @@ var _ = Describe("TimeSlicing", Ordered, Label(tsparams.LabelSuite), func() {
 	})
 })
 
-func EnsureAllGpuPodsAreRunning() {
-	Eventually(func() bool {
-		gpuPods, err := inittools.APIClient.Pods(GPUOperatorNamespace).List(
-			context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			glog.Errorf("Error listing GPU operator pods: %v", err)
-
-			return false
-		}
-
-		if len(gpuPods.Items) < 8 {
-			glog.V(gpuparams.GpuLogLevel).Infof("Waiting for GPU operator pods: %d/8+",
-				len(gpuPods.Items))
-
-			return false
-		}
-
-		for _, p := range gpuPods.Items {
-			glog.V(gpuparams.GpuLogLevel).Infof("Pod %s is %s", p.Name, p.Status.Phase)
-
-			for _, containerStatus := range p.Status.ContainerStatuses {
-				if !containerStatus.Ready && containerStatus.State.Terminated == nil {
-					return false
-				}
-			}
-		}
-
-		return true
-	}, EnsurePodsReadyTimeout, EnsurePodsReadyInterval).Should(BeTrue(),
-		"GPU operator pods did not become ready")
-}
-
 func EnsureOnlyOperatorIsRunning() {
 	Eventually(func() bool {
 		gpuPods, err := inittools.APIClient.Pods(GPUOperatorNamespace).List(
@@ -241,19 +213,33 @@ func EnsureOnlyOperatorIsRunning() {
 			return false
 		}
 
-		if len(gpuPods.Items) > 1 || len(gpuPods.Items) == 0 {
-			glog.V(gpuparams.GpuLogLevel).Infof(
-				"Waiting for cleanup: %d pods remaining", len(gpuPods.Items))
-
-			return false
-		}
+		var nonOperatorPods []string
 
 		for _, p := range gpuPods.Items {
-			for _, containerStatus := range p.Status.ContainerStatuses {
-				if !containerStatus.Ready && containerStatus.State.Terminated == nil {
-					return false
+			if p.Labels["app"] == "gpu-operator" {
+				for _, cs := range p.Status.ContainerStatuses {
+					if !cs.Ready && cs.State.Terminated == nil {
+						glog.V(gpuparams.GpuLogLevel).Infof(
+							"Operator pod %s not ready yet", p.Name)
+
+						return false
+					}
 				}
+
+				continue
 			}
+
+			if p.Status.Phase != corev1.PodSucceeded && p.DeletionTimestamp == nil {
+				nonOperatorPods = append(nonOperatorPods, p.Name)
+			}
+		}
+
+		if len(nonOperatorPods) > 0 {
+			glog.V(gpuparams.GpuLogLevel).Infof(
+				"Waiting for cleanup: %d non-operator pods remaining: %v",
+				len(nonOperatorPods), nonOperatorPods)
+
+			return false
 		}
 
 		return true

--- a/tests/timeslicing/timeslicing_test.go
+++ b/tests/timeslicing/timeslicing_test.go
@@ -1,0 +1,262 @@
+package timeslicing
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/gpuparams"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/timeslicing"
+	"github.com/rh-ecosystem-edge/nvidia-ci/internal/tsparams"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/configmap"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/namespace"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/nodes"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/nvidiagpu"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/pod"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	TestNamespace             = "test-timeslicing"
+	DevicePluginConfigMapName = "plugin-config"
+	GPUOperatorNamespace      = "nvidia-gpu-operator"
+	TimeSlicingReplicas       = 4
+	TimeSlicingImage          = "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0"
+	EnsurePodsReadyTimeout    = "25m"
+	EnsurePodsReadyInterval   = "30s"
+)
+
+var _ = Describe("TimeSlicing", Ordered, Label(tsparams.LabelSuite), func() {
+	var (
+		nsBuilder     *namespace.Builder
+		configMap     *configmap.Builder
+		clusterPolicy *nvidiagpu.Builder
+	)
+
+	BeforeAll(func() {
+		glog.V(gpuparams.GpuLogLevel).Info("Starting TimeSlicing test suite")
+
+		if tmpClusterPolicyBuilder, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName); err == nil {
+			if _, err := tmpClusterPolicyBuilder.Get(); err == nil {
+				if _, err := tmpClusterPolicyBuilder.Delete(); err != nil {
+					glog.Errorf("Error deleting cluster policy: %v", err)
+				} else {
+					EnsureOnlyOperatorIsRunning()
+				}
+			} else {
+				glog.Error("didn't find cluster policy")
+			}
+		}
+
+		nsBuilder = namespace.NewBuilder(inittools.APIClient, TestNamespace)
+		if !nsBuilder.Exists() {
+			createdNsBuilder, err := nsBuilder.Create()
+			Expect(err).ToNot(HaveOccurred(), "error creating namespace %s: %v", TestNamespace, err)
+
+			labeledNsBuilder := createdNsBuilder.WithMultipleLabels(map[string]string{
+				"openshift.io/cluster-monitoring":    "true",
+				"pod-security.kubernetes.io/enforce": "privileged",
+			})
+
+			_, err = labeledNsBuilder.Update()
+			Expect(err).ToNot(HaveOccurred(), "error labeling namespace %s: %v", TestNamespace, err)
+		}
+	})
+
+	AfterEach(func() {
+		if configMap != nil {
+			if err := configMap.Delete(); err != nil {
+				glog.Errorf("Error deleting ConfigMap %s: %v", configMap.Object.Name, err)
+			}
+		}
+
+		if clusterPolicy != nil {
+			if _, err := clusterPolicy.Delete(); err != nil {
+				glog.Errorf("Error deleting cluster policy: %v", err)
+			}
+
+			EnsureOnlyOperatorIsRunning()
+		}
+	})
+
+	AfterAll(func() {
+		if err := nsBuilder.Delete(); err != nil {
+			glog.Errorf("Error deleting namespace %s: %v", TestNamespace, err)
+		}
+	})
+
+	Context("Time-slicing GPU workload", Label("timeslicing-workload"), func() {
+		It("Should run multiple concurrent CUDA workloads on a time-sliced GPU", Label("timeslicing"), func() {
+			var err error
+
+			By("Creating device plugin ConfigMap with time-slicing configuration")
+			configMap, err = timeslicing.CreateDevicePluginConfigMap(
+				inittools.APIClient,
+				TimeSlicingReplicas,
+				DevicePluginConfigMapName,
+				GPUOperatorNamespace,
+				false,
+			)
+			Expect(err).ToNot(HaveOccurred(), "error creating device plugin ConfigMap: %v", err)
+
+			By("Creating ClusterPolicy from CSV with time-slicing device plugin config")
+			clusterPolicy, err = timeslicing.CreateClusterPolicyFromCSV(
+				inittools.APIClient, GPUOperatorNamespace, nvidiagpu.ClusterPolicyName)
+			Expect(err).ToNot(HaveOccurred(), "error creating cluster policy: %v", err)
+
+			By("Waiting for all GPU operator pods to be running")
+			EnsureAllGpuPodsAreRunning()
+
+			By("Verifying node labels reflect time-slicing configuration")
+			clusterNodes, err := nodes.List(inittools.APIClient)
+			Expect(err).ToNot(HaveOccurred(), "error listing nodes: %v", err)
+
+			foundTimeSlicingNode := false
+
+			for _, clusterNode := range clusterNodes {
+				strategy, hasStrategy := clusterNode.Object.Labels["nvidia.com/gpu.sharing-strategy"]
+				if hasStrategy && strategy == "time-slicing" {
+					foundTimeSlicingNode = true
+					replicas := clusterNode.Object.Labels["nvidia.com/gpu.replicas"]
+					Expect(replicas).To(Equal(fmt.Sprintf("%d", TimeSlicingReplicas)),
+						"expected %d replicas on node %s, got %s",
+						TimeSlicingReplicas, clusterNode.Object.Name, replicas)
+
+					allocatable := clusterNode.Object.Status.Allocatable["nvidia.com/gpu"]
+					allocatableGPUs := allocatable.Value()
+					Expect(allocatableGPUs).To(Equal(int64(TimeSlicingReplicas)),
+						"expected %d allocatable GPUs on node %s, got %d",
+						TimeSlicingReplicas, clusterNode.Object.Name, allocatableGPUs)
+
+					glog.V(gpuparams.GpuLogLevel).Infof(
+						"Node %s: sharing-strategy=%s, replicas=%s, allocatable=%d",
+						clusterNode.Object.Name, strategy, replicas, allocatableGPUs)
+				}
+			}
+
+			Expect(foundTimeSlicingNode).To(BeTrue(), "no node found with time-slicing sharing strategy")
+
+			By(fmt.Sprintf("Creating %d CUDA vectoradd pods", TimeSlicingReplicas))
+
+			for i := 1; i <= TimeSlicingReplicas; i++ {
+				podName := fmt.Sprintf("timeslice-test-%d", i)
+				testPod := timeslicing.CreateTimeSlicingTestPod(podName, TestNamespace, TimeSlicingImage)
+
+				_, err = inittools.APIClient.Pods(TestNamespace).Create(
+					context.TODO(), testPod, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred(),
+					"error creating pod %s: %v", podName, err)
+
+				DeferCleanup(func() {
+					podBuilder, pullErr := pod.Pull(inittools.APIClient, podName, TestNamespace)
+					if pullErr != nil {
+						glog.Errorf("Error pulling pod %s: %v", podName, pullErr)
+
+						return
+					}
+
+					if _, deleteErr := podBuilder.Delete(); deleteErr != nil {
+						glog.Errorf("Error deleting pod %s: %v", podName, deleteErr)
+					}
+				})
+			}
+
+			By("Waiting for all pods to reach Succeeded phase")
+
+			for i := 1; i <= TimeSlicingReplicas; i++ {
+				podName := fmt.Sprintf("timeslice-test-%d", i)
+				podBuilder, err := pod.Pull(inittools.APIClient, podName, TestNamespace)
+				Expect(err).ToNot(HaveOccurred(), "error pulling pod %s: %v", podName, err)
+
+				err = podBuilder.WaitUntilInStatus(corev1.PodSucceeded, 3*time.Minute)
+				Expect(err).ToNot(HaveOccurred(),
+					"timeout waiting for pod %s to succeed: %v", podName, err)
+			}
+
+			By("Verifying CUDA test passed in all pod logs")
+
+			for i := 1; i <= TimeSlicingReplicas; i++ {
+				podName := fmt.Sprintf("timeslice-test-%d", i)
+				podBuilder, err := pod.Pull(inittools.APIClient, podName, TestNamespace)
+				Expect(err).ToNot(HaveOccurred(), "error pulling pod %s: %v", podName, err)
+
+				logs, err := podBuilder.GetLog(500*time.Second, "cuda-vectoradd")
+				Expect(err).ToNot(HaveOccurred(),
+					"error getting logs for pod %s: %v", podName, err)
+
+				Expect(strings.Contains(logs, "Test PASSED")).To(BeTrue(),
+					"CUDA vectoradd test did not pass in pod %s, logs:\n%s", podName, logs)
+
+				glog.V(gpuparams.GpuLogLevel).Infof("Pod %s: CUDA vectoradd test PASSED", podName)
+			}
+		})
+	})
+})
+
+func EnsureAllGpuPodsAreRunning() {
+	Eventually(func() bool {
+		gpuPods, err := inittools.APIClient.Pods(GPUOperatorNamespace).List(
+			context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			glog.Errorf("Error listing GPU operator pods: %v", err)
+
+			return false
+		}
+
+		if len(gpuPods.Items) < 8 {
+			glog.V(gpuparams.GpuLogLevel).Infof("Waiting for GPU operator pods: %d/8+",
+				len(gpuPods.Items))
+
+			return false
+		}
+
+		for _, p := range gpuPods.Items {
+			glog.V(gpuparams.GpuLogLevel).Infof("Pod %s is %s", p.Name, p.Status.Phase)
+
+			for _, containerStatus := range p.Status.ContainerStatuses {
+				if !containerStatus.Ready && containerStatus.State.Terminated == nil {
+					return false
+				}
+			}
+		}
+
+		return true
+	}, EnsurePodsReadyTimeout, EnsurePodsReadyInterval).Should(BeTrue(),
+		"GPU operator pods did not become ready")
+}
+
+func EnsureOnlyOperatorIsRunning() {
+	Eventually(func() bool {
+		gpuPods, err := inittools.APIClient.Pods(GPUOperatorNamespace).List(
+			context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			glog.Errorf("Error listing GPU operator pods: %v", err)
+
+			return false
+		}
+
+		if len(gpuPods.Items) > 1 || len(gpuPods.Items) == 0 {
+			glog.V(gpuparams.GpuLogLevel).Infof(
+				"Waiting for cleanup: %d pods remaining", len(gpuPods.Items))
+
+			return false
+		}
+
+		for _, p := range gpuPods.Items {
+			for _, containerStatus := range p.Status.ContainerStatuses {
+				if !containerStatus.Ready && containerStatus.State.Terminated == nil {
+					return false
+				}
+			}
+		}
+
+		return true
+	}, EnsurePodsReadyTimeout, EnsurePodsReadyInterval).Should(BeTrue(),
+		"GPU operator pods did not reach expected state after cleanup")
+}


### PR DESCRIPTION
Add a timeslicing test that:
1. Deletes any existing ClusterPolicy, creates a ConfigMap with time-slicing config (4 replicas), recreates the ClusterPolicy from the CSV ALM examples referencing that ConfigMap
2. Waits for all GPU operator pods to be ready
3. Verifies node labels (`sharing-strategy=time-slicing`, `replicas=4`) and allocatable GPUs = 4
4. Launches 4 CUDA vectoradd pods concurrently, each requesting 1 GPU
5. Asserts all 4 pods succeed with "Test PASSED" in logs
6. Cleans up everything (pods, ConfigMap, ClusterPolicy, namespace)

The test takes aprox. ~ 5 minutes:
```
KUBECONFIG=$HOME/.kube/config TEST_FEATURES=timeslicing TEST_LABELS=timeslicing make run-tests
test -s scripts/gpu-operator-must-gather.sh || (\
        SCRIPT_URL="https://raw.githubusercontent.com/NVIDIA/gpu-operator/v25.10.1/hack/must-gather.sh" && \
        if ! curl -SsLf -o scripts/gpu-operator-must-gather.sh $SCRIPT_URL; then \
                echo "Failed to download must-gather script" >&2; \
                exit 1; \
        fi && \
        chmod +x scripts/gpu-operator-must-gather.sh \
    )
test -s scripts/nfd-must-gather.sh || (\
        SCRIPT_URL="https://raw.githubusercontent.com/openshift/cluster-nfd-operator/refs/heads/release-4.22/must-gather/gather" && \
        if ! curl -SsLf -o scripts/nfd-must-gather.sh $SCRIPT_URL; then \
                echo "Failed to download NFD must-gather script" >&2; \
                exit 1; \
        fi && \
        chmod +x scripts/nfd-must-gather.sh \
)
Executing nvidiagpu test-runner script
scripts/test-runner.sh
PATH_TO_MUST_GATHER_SCRIPT=/home/jose/dev/nvidia-ci/scripts/gpu-operator-tests-must-gather.sh ginkgo -timeout=24h --keep-going --require-suite -r --label-filter="timeslicing" ./tests/timeslicing
2026/06/02 14:57:53 Creating new GeneralConfig struct
2026/06/02 14:57:53 Loading kube client config from path "/home/jose/.kube/config"
Running Suite: TimeSlicing - /home/jose/dev/nvidia-ci/tests/timeslicing
[nvidia-ci, timeslicing]
=======================================================================
Random Seed: 1780405069

Will run 1 of 1 specs
•

Ran 1 of 1 Specs in 230.460 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 3m54.242768608s
Test Suite Passed
```

Assisted-by: Claude 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite validating GPU time-slicing: config deployment, policy application, node labeling, concurrent GPU workloads, and end-to-end pod success/log checks.

* **Documentation**
  * Added README instructions for running the time-slicing test suite and required test flags.

* **Chores**
  * Updated .gitignore to exclude additional script files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->