### PR TITLE
NVIDIA-873 Fix NFD label missmatch OCP.21+

### DIFF
--- a/pkg/nvidiagpu/consts.go
+++ b/pkg/nvidiagpu/consts.go
@@ -14,11 +14,10 @@ const (
 	NvidiaGPUNamespace = "nvidia-gpu-operator"
 
 	// NvidiaGPULabel is the legacy NFD label for NVIDIA GPU presence (vendor ID only, pre-4.21).
-	NvidiaGPULabel = "feature.node.kubernetes.io/pci-10de.present"
-	// nfdLabelPrefix is the common prefix for NFD PCI labels.
-	nfdLabelPrefix = "feature.node.kubernetes.io/pci-"
-	// nfdNvidiaVendorSuffix is the NVIDIA vendor ID suffix in NFD PCI labels.
+	NvidiaGPULabel        = "feature.node.kubernetes.io/pci-10de.present"
+	nfdLabelPrefix        = "feature.node.kubernetes.io/pci-"
 	nfdNvidiaVendorSuffix = "_10de.present"
+
 	GPUPresentLabel                  = "nvidia.com/gpu.present"
 	GPUCapacityKey                   = "nvidia.com/gpu"
 	DevicePluginLabel                = "app=nvidia-device-plugin-daemonset"

--- a/pkg/nvidiagpu/consts.go
+++ b/pkg/nvidiagpu/consts.go
@@ -1,11 +1,24 @@
 package nvidiagpu
 
-import "time"
+import (
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/clients"
+	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/nodes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	NvidiaGPUNamespace = "nvidia-gpu-operator"
 
-	NvidiaGPULabel                   = "feature.node.kubernetes.io/pci-10de.present"
+	// NvidiaGPULabel is the legacy NFD label for NVIDIA GPU presence (vendor ID only, pre-4.21).
+	NvidiaGPULabel = "feature.node.kubernetes.io/pci-10de.present"
+	// nfdLabelPrefix is the common prefix for NFD PCI labels.
+	nfdLabelPrefix = "feature.node.kubernetes.io/pci-"
+	// nfdNvidiaVendorSuffix is the NVIDIA vendor ID suffix in NFD PCI labels.
+	nfdNvidiaVendorSuffix = "_10de.present"
 	GPUPresentLabel                  = "nvidia.com/gpu.present"
 	GPUCapacityKey                   = "nvidia.com/gpu"
 	DevicePluginLabel                = "app=nvidia-device-plugin-daemonset"
@@ -72,3 +85,31 @@ const (
 	LabelCheckInterval = 15 * time.Second
 	LabelCheckTimeout  = 3 * time.Minute
 )
+
+// ResolveGPULabel returns the NFD GPU label present on the cluster.
+// NFD 4.21+ uses pci-{class}_10de.present (e.g. pci-0302_10de.present),
+// older versions use pci-10de.present (vendor only).
+// This function checks worker nodes for any label matching the pattern.
+func ResolveGPULabel(apiClient *clients.Settings) string {
+	nodeList, err := nodes.List(apiClient, metav1.ListOptions{})
+	if err != nil {
+		glog.V(90).Infof("Error listing nodes: %v, defaulting to '%s'", err, NvidiaGPULabel)
+
+		return NvidiaGPULabel
+	}
+
+	for _, node := range nodeList {
+		for label := range node.Object.Labels {
+			if strings.HasPrefix(label, nfdLabelPrefix) && strings.HasSuffix(label, nfdNvidiaVendorSuffix) {
+				glog.V(90).Infof("Resolved GPU label to '%s' on node '%s'", label, node.Object.Name)
+
+				return label
+			}
+		}
+	}
+
+	// Fall back to legacy label for pre-NFD clusters or when no nodes are labeled yet.
+	glog.V(90).Infof("No NFD NVIDIA GPU label found on any node, defaulting to '%s'", NvidiaGPULabel)
+
+	return NvidiaGPULabel
+}

--- a/tests/mig/mig_test.go
+++ b/tests/mig/mig_test.go
@@ -51,7 +51,7 @@ var _ = Describe("MIG", Ordered, Label(tsparams.LabelSuite), func() {
 			mig.LogCLIParameterValues()
 
 			WorkerNodeSelector = map[string]string{
-				inittools.GeneralConfig.WorkerLabel:                          "",
+				inittools.GeneralConfig.WorkerLabel:            "",
 				nvidiagpu.ResolveGPULabel(inittools.APIClient): "true",
 			}
 

--- a/tests/mig/mig_test.go
+++ b/tests/mig/mig_test.go
@@ -21,10 +21,7 @@ var (
 	nfdInstance = operatorconfig.NewCustomConfig()
 	burn        = nvidiagpu.NewDefaultGPUBurnConfig()
 
-	WorkerNodeSelector = map[string]string{
-		inittools.GeneralConfig.WorkerLabel: "",
-		nvidiagpu.NvidiaGPULabel:            "true",
-	}
+	WorkerNodeSelector map[string]string
 
 	BurnImageName = map[string]string{
 		"amd64": "quay.io/wabouham/gpu_burn_amd64:ubi9",
@@ -52,6 +49,12 @@ var _ = Describe("MIG", Ordered, Label(tsparams.LabelSuite), func() {
 			// Initialize CLI flag-derived values after flags are parsed
 			mig.ParseCLIParameters()
 			mig.LogCLIParameterValues()
+
+			WorkerNodeSelector = map[string]string{
+				inittools.GeneralConfig.WorkerLabel:                          "",
+				nvidiagpu.ResolveGPULabel(inittools.APIClient): "true",
+			}
+
 			nvidiaGPUConfig = nvidiagpuconfig.NewNvidiaGPUConfig()
 			Expect(nvidiaGPUConfig).ToNot(BeNil(), "Failed to initialize NvidiaGPUConfig")
 

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -105,7 +105,7 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 			glog.V(0).Infof("Start of the test case, BeforeAll")
 
 			WorkerNodeSelector = map[string]string{
-				inittools.GeneralConfig.WorkerLabel:                          "",
+				inittools.GeneralConfig.WorkerLabel:            "",
 				nvidiagpu.ResolveGPULabel(inittools.APIClient): "true",
 			}
 

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -52,10 +52,7 @@ var (
 
 	InstallPlanApproval v1alpha1.Approval = "Automatic"
 
-	WorkerNodeSelector = map[string]string{
-		inittools.GeneralConfig.WorkerLabel: "",
-		nvidiagpu.NvidiaGPULabel:            "true",
-	}
+	WorkerNodeSelector map[string]string
 
 	BurnImageName = map[string]string{
 		"amd64": "quay.io/wabouham/gpu_burn_amd64:ubi9",
@@ -106,6 +103,12 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 		BeforeAll(func() {
 			glog.V(0).Infof("Start of the test case, BeforeAll")
+
+			WorkerNodeSelector = map[string]string{
+				inittools.GeneralConfig.WorkerLabel:                          "",
+				nvidiagpu.ResolveGPULabel(inittools.APIClient): "true",
+			}
+
 			if nvidiaGPUConfig.InstanceType == "" {
 				glog.V(gpuparams.GpuLogLevel).Infof("env variable NVIDIAGPU_GPU_MACHINESET_INSTANCE_TYPE" +
 					" is not set, skipping scaling cluster")
@@ -278,7 +281,8 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 			nfdcheck.CheckNfdInstallation(inittools.APIClient, nfd.OSLabel, nfd.GetAllowedOSLabels(), inittools.GeneralConfig.WorkerLabelMap, networkparams.LogLevel)
 
 			By("Check if at least one worker node is GPU enabled")
-			gpuNodeFound, _ := check.NodeWithLabel(inittools.APIClient, nvidiagpu.NvidiaGPULabel, inittools.GeneralConfig.WorkerLabelMap)
+			gpuLabel := nvidiagpu.ResolveGPULabel(inittools.APIClient)
+			gpuNodeFound, _ := check.NodeWithLabel(inittools.APIClient, gpuLabel, inittools.GeneralConfig.WorkerLabelMap)
 
 			glog.V(gpuparams.GpuLogLevel).Infof("The check for Nvidia GPU label returned: %v", gpuNodeFound)
 


### PR DESCRIPTION
Closes https://github.com/rh-ecosystem-edge/nvidia-ci/issues/554

**Needs testing** I dont have a MIG enabled cluster available atm

Assisted-by: Claude 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GPU label detection is now dynamic and automatically resolves the correct label format for your cluster configuration, with support for NVIDIA NFD 4.21+ and legacy label formats for improved compatibility.

* **Tests**
  * Updated test suite to use runtime-based GPU label resolution instead of static predefined labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->