### PR TITLE
Update tracking workflows to OCP4.23

### DIFF
--- a/.github/workflows/track_catalog_gpu.yaml
+++ b/.github/workflows/track_catalog_gpu.yaml
@@ -7,7 +7,7 @@ on:
       ocp_version:
         description: 'OpenShift version to check'
         required: false
-        default: '4.22'
+        default: '4.23'
       index_name:
         description: 'Operator index name'
         required: false
@@ -27,7 +27,7 @@ jobs:
     with:
       operator_display_name: 'GPU'
       index_name: ${{ github.event.inputs.index_name || 'certified-operator-index' }}
-      ocp_version: ${{ github.event.inputs.ocp_version || '4.22' }}
+      ocp_version: ${{ github.event.inputs.ocp_version || '4.23' }}
       operator_name: ${{ github.event.inputs.operator_name || 'gpu-operator-certified' }}
     secrets:
       registry_username: ${{ secrets.REGISTRY_REDHAT_USERNAME }}

--- a/.github/workflows/track_catalog_nfd.yaml
+++ b/.github/workflows/track_catalog_nfd.yaml
@@ -7,7 +7,7 @@ on:
       ocp_version:
         description: 'OpenShift version to check'
         required: false
-        default: '4.22'
+        default: '4.23'
       index_name:
         description: 'Operator index name'
         required: false
@@ -27,7 +27,7 @@ jobs:
     with:
       operator_display_name: 'NFD'
       index_name: ${{ github.event.inputs.index_name || 'redhat-operator-index' }}
-      ocp_version: ${{ github.event.inputs.ocp_version || '4.22' }}
+      ocp_version: ${{ github.event.inputs.ocp_version || '4.23' }}
       operator_name: ${{ github.event.inputs.operator_name || 'nfd' }}
     secrets:
       registry_username: ${{ secrets.REGISTRY_REDHAT_USERNAME }}


### PR DESCRIPTION
Closes https://github.com/rh-ecosystem-edge/nvidia-ci/issues/561 https://github.com/rh-ecosystem-edge/nvidia-ci/issues/560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default OpenShift version in CI/CD workflows from 4.22 to 4.23

<!-- end of auto-generated comment: release notes by coderabbit.ai -->