### PR TITLE
Time-slicing MIG testcase for Nvidia GPU operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ NVIDIA Network Operator-specific (NNO) parameters for the script are controlled 
 
 NVIDIA MIG parameters for the script are controlled by the following ginkgo parameters which are delivered as `ARGS="-- [{parameter}...]"` for the `make run-tests` (check the examples):
 
-- `--single.mig-profile=n`, where n is typically a value of int type between 0-5. The parameter is used to choose the MIG profile from list of available MIG profiles (e.g. 1g.5gb is usually referenced with index 0).  If not specified, a valid random number is used. Typically values 0-5. - *optional*
+- `--single.mig.profile=n`, where n is typically a value of int type between 0-5. The parameter is used to choose the MIG profile from list of available MIG profiles (e.g. 1g.5gb is usually referenced with index 0).  If not specified, a valid random number is used. Typically values 0-5. - *optional*
 - `--mixed.mig.instances=xxx`, where xxx is a comma-separated string inside quotation marks (e.g. "2,0,1,1,0,0") The list of numbers represent how many instances are to be used for each profile when creating a pod. The first number indicates how many instances are to be used for the first profile etc. The instances of different profiles consume GPU slices in a different way. The name of the profile (e.g. 2g.10gb) describes the consumption of each instance (each instance would consume 2 slices and 10gb of memory). *optional*
 - `--mixed.mig.pod-delay=n`, where n is a number in range 0 - 315 (seconds). In mixed MIG testcase there are usually more than 1 pod launched (depends on available GPU and mixed.mig.instances parameter). Since GPU workload is 300 seconds, this parameter can be used to control the delay between the pod launches so that the pods are running completely simultaneously, mostly overlapping (e.g. 15-80), slightly overlapping (e.g. 200-280 seconds), or non-overlapping (over 300 seconds). Values outside valid range are reset to closest limit (either 0 or 315). *optional*
 - `--time.slicing.instances=xxx`, where xxx is a comma-separated string inside quotation marks (e.g. "1,2,3,4,5,6,7,8"). Default is "8". The list of numbers represent how many timeslices for each pod is to be created. In the previous example the first pod would get 1 time-slice, second one would get 2, etc. They may run simultaneously as long as they don't exceed the maximum value (8) that can run simultaneously. Any pods that is not getting the resources will stay in pending state until the requested resources become available. Any pod with requested 8 time-slices will run alone. The sum of the values is currently restricted to 100.
@@ -229,7 +229,7 @@ included) , mixed-mig testcase would use 1 instance amount for A100 GPU (1x 1g.5
 leaving the second profile 1g.10gb unused).
 mixed-mig testcase would wait 35 seconds between the pods launching with mixed.mig.pod-delay parameter
 time-slicing testcase would launch 8 pods, with 1 time-slice each, allowing them to be executed at the same time
-You can deliver the ginkgo cli parameter using ARGS after the "make run-tests"
+You can deliver the ginkgo cli parameter using ARGS after the "make run-mig-tests"
 
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ NVIDIA MIG parameters for the script are controlled by the following ginkgo para
 - `--single.mig-profile=n`, where n is typically a value of int type between 0-5. The parameter is used to choose the MIG profile from list of available MIG profiles (e.g. 1g.5gb is usually referenced with index 0).  If not specified, a valid random number is used. Typically values 0-5. - *optional*
 - `--mixed.mig.instances=xxx`, where xxx is a comma-separated string inside quotation marks (e.g. "2,0,1,1,0,0") The list of numbers represent how many instances are to be used for each profile when creating a pod. The first number indicates how many instances are to be used for the first profile etc. The instances of different profiles consume GPU slices in a different way. The name of the profile (e.g. 2g.10gb) describes the consumption of each instance (each instance would consume 2 slices and 10gb of memory). *optional*
 - `--mixed.mig.pod-delay=n`, where n is a number in range 0 - 315 (seconds). In mixed MIG testcase there are usually more than 1 pod launched (depends on available GPU and mixed.mig.instances parameter). Since GPU workload is 300 seconds, this parameter can be used to control the delay between the pod launches so that the pods are running completely simultaneously, mostly overlapping (e.g. 15-80), slightly overlapping (e.g. 200-280 seconds), or non-overlapping (over 300 seconds). Values outside valid range are reset to closest limit (either 0 or 315). *optional*
-- --time.slicing.instances="n". Default is 8. There may be a comma-separated list of values, as many as pod-count indicates. The values indicate how many timeslices for each pod is to be created (e.g. "1,2,3,4,5,6,7,8", meaning that first pod would get 1 time-slice, second one would get 2, etc.). They may run simultaneously as long as they don't exceed the maximum value (8). Any pods that is not getting the resources will stay in pending state until the requested resources become available. Any pod with requested 8 time-slices will run alone. The sum of the values is currently restricted to 100.
-- --time.slicing.mon-after-pod=n. Default is 0, meaning that process monitoring will start immediately. If there are 5 instances and mon-after-pod=4, the process monitoring would only start after 4th pod. There may be previous pods still running depending on how many time-slices they have been allocated. Any number exceeding the number of instances will prevent the process monitoring
+- `--time.slicing.instances=xxx`, where xxx is a comma-separated string inside quotation marks (e.g. "1,2,3,4,5,6,7,8"). Default is "8". The list of numbers represent how many timeslices for each pod is to be created. In the previous example the first pod would get 1 time-slice, second one would get 2, etc. They may run simultaneously as long as they don't exceed the maximum value (8) that can run simultaneously. Any pods that is not getting the resources will stay in pending state until the requested resources become available. Any pod with requested 8 time-slices will run alone. The sum of the values is currently restricted to 100.
+- `--time.slicing.mon-after-pod=n`. Default is 0, meaning that process monitoring will start immediately. If there are 5 instances and mon-after-pod=4, the process monitoring would only start after 4th pod. There may be previous pods still running depending on how many time-slices they have been allocated. Any number exceeding the number of instances will prevent the process monitoring
 
 
 
@@ -205,7 +205,7 @@ It is recommended to execute the runner script through the `make run-tests` make
 
 #### Steps to run MIG tests:
 
-1. Run mig testcases (single-mig and mixed-mig) after nvidia-ci on any cluster, while selecting single.mig.profile=1 and 2 time-slicing pods, which do not run at the same time because their sum would exceed the maximum number of time-slices (8).
+1. Run mig testcases (single-mig, mixed-mig and time-slicing) after nvidia-ci on any cluster, while selecting single.mig.profile=1 and 2 time-slicing pods, which do not run at the same time because their sum would exceed the maximum number of simultaneous time-slices (8). Without any mixed-mig arguments, it will run as default.
 
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
@@ -219,7 +219,7 @@ $ export NVIDIAGPU_CLEANUP=false
 $ make run-tests ARGS="-- --single.mig.profile=1 --time.slicing.instances=3,8"
 ```
 
-1. Running only MIG testcases on an existing cluster which has GPU operator installed,
+1. Running only MIG testcases (make run-mig-tests) on an existing cluster which has GPU operator installed,
 
 e.g. after executing step 1. MIG testcase(s) can be used from either nvidiagpu or
 mig package. MIG is used in this example. In the other case, use `TEST_FEATURES="nvidiagpu"`

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ $ export TEST_LABELS='nvidia-ci,gpu,single-mig,mixed-mig,time-slicing'
 $ export TEST_TRACE=true
 $ export VERBOSE_LEVEL=100
 $ export NVIDIAGPU_CLEANUP=false
-$ make run-tests ARGS="-- --single.mig.profile=1" --time.slicing.instances="3,8"
+$ make run-tests ARGS="-- --single.mig.profile=1 --time.slicing.instances=3,8"
 ```
 
 1. Running only MIG testcases on an existing cluster which has GPU operator installed,
@@ -240,7 +240,7 @@ $ export TEST_LABELS='single-mig,mixed-mig,time-slicing'
 $ export TEST_TRACE=true
 $ export VERBOSE_LEVEL=100
 $ export NVIDIAGPU_CLEANUP=false
-$ make run-mig-tests ARGS="-- --mixed.mig.instances='1,0,1,1' --mixed.mig.pod-delay=35" --time.slicing.instances="1,1,1,1,1,1,1,1"
+$ make run-mig-tests ARGS="-- --mixed.mig.instances='1,0,1,1' --mixed.mig.pod-delay=35 --time.slicing.instances=1,1,1,1,1,1,1,1"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,61 +1,77 @@
-Ecosystem Edge NVIDIA-CI - Golang Automation CI
-=======
+# Ecosystem Edge NVIDIA-CI - Golang Automation CI
+
 # NVIDIA-CI
 
 ## Overview
+
 This repository is an automation/CI framework to test NVIDIA operators, the GPU Operator and Network Operator.
 This project is based on golang + [ginkgo](https://onsi.github.io/ginkgo) framework.
 
 ### Project requirements
+
 Golang and ginkgo versions based on versions specified in `go.mod` file.
 
 The framework in this repository is designed to test NVIDIA's operators on a pre-installed OpenShift Container Platform
 (OCP) cluster which meets the following requirements:
 
-* OCP cluster installed with version >=4.12
+- OCP cluster installed with version >=4.12
 
 ### Supported setups
-* Regular cluster 3 master nodes (VMs or BMs) and minimum of 2 workers (VMs or BMs)
-* Single Node Cluster (VM or BM)
-* Public Clouds Cluster (AWS, GCP and Azure) - For GPU Operator Only
-* On Premise Cluster
+
+- Regular cluster 3 master nodes (VMs or BMs) and minimum of 2 workers (VMs or BMs)
+- Single Node Cluster (VM or BM)
+- Public Clouds Cluster (AWS, GCP and Azure) - For GPU Operator Only
+- On Premise Cluster
+
+
 
 ### General environment variables
+
+
+
 #### Mandatory:
-* `KUBECONFIG` - Path to kubeconfig file.
+
+- `KUBECONFIG` - Path to kubeconfig file.
+
+
+
 #### Optional:
-* Logging with glog
+
+- Logging with glog
 
 We use glog library for logging. In order to enable verbose logging the following needs to be done:
 
 1. Make sure to import inittool package in your go script, per this example:
 
-<sup>
-    import (
-      . "github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools"
-    )
-</sup>
+import ( . "github.com/rh-ecosystem-edge/nvidia-ci/internal/inittools" )
 
-2. Need to export the following SHELL variable:
+1. Need to export the following SHELL variable:
+
 > export VERBOSE_LEVEL=100
+
+
 
 ##### Notes:
 
-  1. The value for the variable has to be >= 100.
-  2. The variable can simply be exported in the shell where you run your automation.
-  3. The go file you work on has to be in a directory under github.com/rh-ecosystem-edge/nvidia-ci/tests/ directory for being able to import inittools.
-  4. Importing inittool also initializes the api client and it's available via "APIClient" variable.
+1. The value for the variable has to be >= 100.
+2. The variable can simply be exported in the shell where you run your automation.
+3. The go file you work on has to be in a directory under github.com/rh-ecosystem-edge/nvidia-ci/tests/ directory for being able to import inittools.
+4. Importing inittool also initializes the api client and it's available via "APIClient" variable.
 
-* Collect logs from cluster with reporter
+- Collect logs from cluster with reporter
 
 We use k8reporter library for collecting resource from cluster in case of test failure.
 In order to enable k8reporter the following needs to be done:
 
 1. Export DUMP_FAILED_TESTS and set it to true. Use example below
+
 > export DUMP_FAILED_TESTS=true
 
-2. Specify absolute path for logs directory like it appears below.  By default /tmp/reports directory is used.
+1. Specify absolute path for logs directory like it appears below.  By default /tmp/reports directory is used.
+
 > export REPORTS_DUMP_DIR=/tmp/logs_directory
+
+
 
 ## How to run
 
@@ -64,59 +80,70 @@ The test-runner [script](scripts/test-runner.sh) is the recommended way for exec
 ### Environment variables
 
 General Parameters for the script are controlled by the following environment variables:
-- `TEST_FEATURES`: list of features to be tested.  Subdirectories under `tests` dir that match a feature will be included (internal directories are excluded).  When we have more than one subdirectory ot tests, they can be listed comma-separated.- _required_
-- `TEST_LABELS`: ginkgo query passed to the label-filter option for including/excluding tests. Supports comma-separated labels (AND logic) and `||` operator (OR logic). Examples: `'nvidia-ci,gpu'`, `'nvidia-ci,mps'`, `'nvidia-ci,mig'`, `'deploy || rdma-legacy-sriov'` - _optional_
-- `TEST_VERBOSE`: executes ginkgo with verbose test output - _optional_
-- `TEST_TRACE`: includes full stack trace from ginkgo tests when a failure occurs - _optional_
-- `VERBOSE_SCRIPT`: prints verbose script information when executing the script - _optional_
-- `NO_COLOR`: `{true|anything else}` when used, omits the coloring of logs that appear on beginning of the functions. However it does not affect on the coloring of the logs that ginkgo framework generates. - _optional_
+
+- `TEST_FEATURES`: list of features to be tested.  Subdirectories under `tests` dir that match a feature will be included (internal directories are excluded).  When we have more than one subdirectory ot tests, they can be listed comma-separated.- *required*
+- `TEST_LABELS`: ginkgo query passed to the label-filter option for including/excluding tests. Supports comma-separated labels (AND logic) and `||` operator (OR logic). Examples: `'nvidia-ci,gpu'`, `'nvidia-ci,mps'`, `'nvidia-ci,mig'`, `'deploy || rdma-legacy-sriov'` - *optional*
+- `TEST_VERBOSE`: executes ginkgo with verbose test output - *optional*
+- `TEST_TRACE`: includes full stack trace from ginkgo tests when a failure occurs - *optional*
+- `VERBOSE_SCRIPT`: prints verbose script information when executing the script - *optional*
+- `NO_COLOR`: `{true|anything else}` when used, omits the coloring of logs that appear on beginning of the functions. However it does not affect on the coloring of the logs that ginkgo framework generates. - *optional*
 
 NVIDIA GPU Operator-specific parameters for the script are controlled by the following environment variables:
+
 - `NVIDIAGPU_GPU_MACHINESET_INSTANCE_TYPE`: Use only when OCP is on a public cloud, and when you need to scale the cluster to add a GPU-enabled compute node. If cluster already has a GPU enabled worker node, this variable should be unset.
-  - Example instance type: "g4dn.xlarge" in AWS, or "a2-highgpu-1g" in GCP, or "Standard_NC4as_T4_v3" in Azure - _required when need to scale cluster to add GPU node_
-- `NVIDIAGPU_CATALOGSOURCE`: custom catalogsource to be used.  If not specified, the default "certified-operators" catalog is used - _optional_
-- `NVIDIAGPU_SUBSCRIPTION_CHANNEL`: specific subscription channel to be used.  If not specified, the latest channel is used - _optional_
-- `NVIDIAGPU_BUNDLE_IMAGE`: GPU Operator bundle image to deploy with operator-sdk if NVIDIAGPU_DEPLOY_FROM_BUNDLE variable is set to true.  Default value for bundle image if not set: ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:main-latest - _optional when deploying from bundlle_
-- `NVIDIAGPU_DEPLOY_FROM_BUNDLE`: boolean flag to deploy GPU operator from bundle image with operator-sdk - Default value is false - _required when deploying from bundle_
-- `NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL`: specific subscription channel to upgrade to from previous version.  _required when running operator-upgrade testcase_
-- `NVIDIAGPU_CLEANUP`: boolean flag to cleanup up resources created by testcase after testcase execution - Default value is true - _required only when cleanup is not needed_
-- `NVIDIAGPU_GPU_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`: custom certified-operators catalogsource index image for GPU package - _required when deploying fallback custom GPU catalogsource_
+  - Example instance type: "g4dn.xlarge" in AWS, or "a2-highgpu-1g" in GCP, or "Standard_NC4as_T4_v3" in Azure - *required when need to scale cluster to add GPU node*
+- `NVIDIAGPU_CATALOGSOURCE`: custom catalogsource to be used.  If not specified, the default "certified-operators" catalog is used - *optional*
+- `NVIDIAGPU_SUBSCRIPTION_CHANNEL`: specific subscription channel to be used.  If not specified, the latest channel is used - *optional*
+- `NVIDIAGPU_BUNDLE_IMAGE`: GPU Operator bundle image to deploy with operator-sdk if NVIDIAGPU_DEPLOY_FROM_BUNDLE variable is set to true.  Default value for bundle image if not set: ghcr.io/nvidia/gpu-operator/gpu-operator-bundle:main-latest - *optional when deploying from bundlle*
+- `NVIDIAGPU_DEPLOY_FROM_BUNDLE`: boolean flag to deploy GPU operator from bundle image with operator-sdk - Default value is false - *required when deploying from bundle*
+- `NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL`: specific subscription channel to upgrade to from previous version.  *required when running operator-upgrade testcase*
+- `NVIDIAGPU_CLEANUP`: boolean flag to cleanup up resources created by testcase after testcase execution - Default value is true - *required only when cleanup is not needed*
+- `NVIDIAGPU_GPU_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`: custom certified-operators catalogsource index image for GPU package - *required when deploying fallback custom GPU catalogsource*
 - `NVIDIAGPU_GPU_CLUSTER_POLICY_PATCH`: a JSON patch to apply to a default cluster policy from ALM examples, written according to
-   [RFC 6902](http://tools.ietf.org/html/rfc6902) (also see [kubectl patch](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/)) - _optional_
-- `NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`:  custom redhat-operators catalogsource index image for NFD package - _required when deploying fallback custom NFD catalogsource_
+ [RFC 6902](http://tools.ietf.org/html/rfc6902) (also see [kubectl patch](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/)) - *optional*
+- `NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`:  custom redhat-operators catalogsource index image for NFD package - *required when deploying fallback custom NFD catalogsource*
 
 NVIDIA Network Operator-specific (NNO) parameters for the script are controlled by the following environment variables:
-- `NVIDIANETWORK_CATALOGSOURCE`: custom catalogsource to be used.  If not specified, the default "certified-operators" catalog is used - _optional_
-- `NVIDIANETWORK_SUBSCRIPTION_CHANNEL`: specific subscription channel to be used.  If not specified, the latest channel is used - _optional_
-- `NVIDIANETWORK_BUNDLE_IMAGE`: Network Operator bundle image to deploy with operator-sdk if NVIDIANETWORK_DEPLOY_FROM_BUNDLE variable is set to true.  Default value for bundle image if not set: TBD - _optional when deploying from bundlle_
-- `NVIDIANETWORK_DEPLOY_FROM_BUNDLE`: boolean flag to deploy Network Operator from bundle image with operator-sdk - Default value is false - _required when deploying from bundle_
-- `NVIDIANETWORK_SUBSCRIPTION_UPGRADE_TO_CHANNEL`: specific subscription channel to upgrade to from previous version.  _required when running operator-upgrade testcase_
-- `NVIDIANETWORK_CLEANUP`: boolean flag to cleanup up resources created by testcase after testcase execution - Default value is true - _required only when cleanup is not needed_
-- `NVIDIANETWORK_NNO_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`: custom certified-operators catalogsource index image for GPU package - _required when deploying fallback custom NNO catalogsource_
-- `NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`:  custom redhat-operators catalogsource index image for NFD package - _required when deploying fallback custom NFD catalogsource_
-- `NVIDIANETWORK_OFED_DRIVER_VERSION`: OFED Driver Version.  If not specified, the default driver version is used - _optional_
-- `NVIDIANETWORK_OFED_REPOSITORY`:  OFED Driver Repository.   If not specified, the default repository is used - _optional_
-- `NVIDIANETWORK_RDMA_WORKLOAD_NAMESPACE`:  RDMA workload pod namespace - _required_
-- `NVIDIANETWORK_RDMA_LINK_TYPE` Layer 2 link type, Infinband or Ethernet - _required_
-- `NVIDIANETWORK_RDMA_MLX_DEVICE`: mlx5 device ID corresponding to the interface port connected to Spectrum or Infiniband switch - _required_
-- `NVIDIANETWORK_RDMA_CLIENT_HOSTNAME`: RDMA Client hostname of first worker node for ib_write_bw test - _required when running the RDMA testcase_
-- `NVIDIANETWORK_RDMA_SERVER_HOSTNAME`: RDMA Server hostname of second worker node for ib_write_bw test - _required when running the RDMA testcase_
-- `NVIDIANETWORK_RDMA_NETWORK_TYPE`: RDMA network type, e.g. sriov, shared-device.  Defaults to shared-device if not specified - _required when running the RDMA testcase_
-- `NVIDIANETWORK_RDMA_TEST_IMAGE`: RDMA Test Container Image that runs the entrypoint.sh script with optional arguments specified in the pod spec.  This container will clone the "https://github.com/linux-rdma/perftest" repo and builds the ib_write_bw binaries with or without cuda headers.  It will also run the ib_write_bw command with arguments either in CLient or Server mode.  Defaults to "quay.io/wabouham/ecosys-nvidia/rdma-tools:0.0.3" - _optional_
-- `NVIDIANETWORK_RDMA_SRIOV_NETWORK_NAME`: sriovnetwork resource name  -  _required when running the Legacy SRIOV RDMA testcase_
-- `NVIDIANETWORK_MELLANOX_ETH_INTERFACE_NAME`: Mellanox Ethernet Interface Name - Defaults to "ens8f0np0" if not specified - _optional_
-- `NVIDIANETWORK_MELLANOX_IB_INTERFACE_NAME`:  Mellanox Infiniband Interface Name - Defaults to "ens8f0np0" if not specified - _optional_
-- `NVIDIANETWORK_MACVLANNETWORK_NAME`: MacvlanNetwork Custom Resource instance name  - Defaults to name from Cluster Service Version alm-examples section if not specified  - _optional_
-- `NVIDIANETWORK_MACVLANNETWORK_IPAM_RANGE`: MacvlanNetwork Custom Resource instance IPAM or IP Address/Subnet mask range for Eth or IB interface - _required_
-- `NVIDIANETWORK_MACVLANNETWORK_IPAM_GATEWAY`: MacvlanNetwork Custom Resource instance IPAM Default Gateway for specified ip address range - _required_
-- `NVIDIANETWORK_RDMA_GPUDIRECT`: Boolean flag to run RDMA workload with 1 nvidia.com/gpu resource - _optional_
+
+- `NVIDIANETWORK_CATALOGSOURCE`: custom catalogsource to be used.  If not specified, the default "certified-operators" catalog is used - *optional*
+- `NVIDIANETWORK_SUBSCRIPTION_CHANNEL`: specific subscription channel to be used.  If not specified, the latest channel is used - *optional*
+- `NVIDIANETWORK_BUNDLE_IMAGE`: Network Operator bundle image to deploy with operator-sdk if NVIDIANETWORK_DEPLOY_FROM_BUNDLE variable is set to true.  Default value for bundle image if not set: TBD - *optional when deploying from bundlle*
+- `NVIDIANETWORK_DEPLOY_FROM_BUNDLE`: boolean flag to deploy Network Operator from bundle image with operator-sdk - Default value is false - *required when deploying from bundle*
+- `NVIDIANETWORK_SUBSCRIPTION_UPGRADE_TO_CHANNEL`: specific subscription channel to upgrade to from previous version.  *required when running operator-upgrade testcase*
+- `NVIDIANETWORK_CLEANUP`: boolean flag to cleanup up resources created by testcase after testcase execution - Default value is true - *required only when cleanup is not needed*
+- `NVIDIANETWORK_NNO_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`: custom certified-operators catalogsource index image for GPU package - *required when deploying fallback custom NNO catalogsource*
+- `NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`:  custom redhat-operators catalogsource index image for NFD package - *required when deploying fallback custom NFD catalogsource*
+- `NVIDIANETWORK_OFED_DRIVER_VERSION`: OFED Driver Version.  If not specified, the default driver version is used - *optional*
+- `NVIDIANETWORK_OFED_REPOSITORY`:  OFED Driver Repository.   If not specified, the default repository is used - *optional*
+- `NVIDIANETWORK_RDMA_WORKLOAD_NAMESPACE`:  RDMA workload pod namespace - *required*
+- `NVIDIANETWORK_RDMA_LINK_TYPE` Layer 2 link type, Infinband or Ethernet - *required*
+- `NVIDIANETWORK_RDMA_MLX_DEVICE`: mlx5 device ID corresponding to the interface port connected to Spectrum or Infiniband switch - *required*
+- `NVIDIANETWORK_RDMA_CLIENT_HOSTNAME`: RDMA Client hostname of first worker node for ib_write_bw test - *required when running the RDMA testcase*
+- `NVIDIANETWORK_RDMA_SERVER_HOSTNAME`: RDMA Server hostname of second worker node for ib_write_bw test - *required when running the RDMA testcase*
+- `NVIDIANETWORK_RDMA_NETWORK_TYPE`: RDMA network type, e.g. sriov, shared-device.  Defaults to shared-device if not specified - *required when running the RDMA testcase*
+- `NVIDIANETWORK_RDMA_TEST_IMAGE`: RDMA Test Container Image that runs the entrypoint.sh script with optional arguments specified in the pod spec.  This container will clone the "[https://github.com/linux-rdma/perftest](https://github.com/linux-rdma/perftest)" repo and builds the ib_write_bw binaries with or without cuda headers.  It will also run the ib_write_bw command with arguments either in CLient or Server mode.  Defaults to "quay.io/wabouham/ecosys-nvidia/rdma-tools:0.0.3" - *optional*
+- `NVIDIANETWORK_RDMA_SRIOV_NETWORK_NAME`: sriovnetwork resource name  -  *required when running the Legacy SRIOV RDMA testcase*
+- `NVIDIANETWORK_MELLANOX_ETH_INTERFACE_NAME`: Mellanox Ethernet Interface Name - Defaults to "ens8f0np0" if not specified - *optional*
+- `NVIDIANETWORK_MELLANOX_IB_INTERFACE_NAME`:  Mellanox Infiniband Interface Name - Defaults to "ens8f0np0" if not specified - *optional*
+- `NVIDIANETWORK_MACVLANNETWORK_NAME`: MacvlanNetwork Custom Resource instance name  - Defaults to name from Cluster Service Version alm-examples section if not specified  - *optional*
+- `NVIDIANETWORK_MACVLANNETWORK_IPAM_RANGE`: MacvlanNetwork Custom Resource instance IPAM or IP Address/Subnet mask range for Eth or IB interface - *required*
+- `NVIDIANETWORK_MACVLANNETWORK_IPAM_GATEWAY`: MacvlanNetwork Custom Resource instance IPAM Default Gateway for specified ip address range - *required*
+- `NVIDIANETWORK_RDMA_GPUDIRECT`: Boolean flag to run RDMA workload with 1 nvidia.com/gpu resource - *optional*
+
+
 
 ### CLI parameters:
 
 NVIDIA MIG parameters for the script are controlled by the following ginkgo parameters which are delivered as `ARGS="-- [{parameter}...]"` for the `make run-tests` (check the examples):
-- `--single.mig-profile=n`, where n is typically a value of int type between 0-5. The parameter is used to choose the MIG profile from list of available MIG profiles (e.g. 1g.5gb is usually referenced with index 0).  If not specified, a valid random number is used. Typically values 0-5. - _optional_
-- `--mixed.mig.instances=xxx`, where xxx is a comma-separated string inside quotation marks (e.g. "2,0,1,1,0,0") The list of numbers represent how many instances are to be used for each profile when creating a pod. The first number indicates how many instances are to be used for the first profile etc. The instances of different profiles consume GPU slices in a different way. The name of the profile (e.g. 2g.10gb) describes the consumption of each instance (each instance would consume 2 slices and 10gb of memory). _optional_
-- `--mixed.mig.pod-delay=n`, where n is a number in range 0 - 315 (seconds). In mixed MIG testcase there are usually more than 1 pod launched (depends on available GPU and mixed.mig.instances parameter). Since GPU workload is 300 seconds, this parameter can be used to control the delay between the pod launches so that the pods are running completely simultaneously, mostly overlapping (e.g. 15-80), slightly overlapping (e.g. 200-280 seconds), or non-overlapping (over 300 seconds). Values outside valid range are reset to closest limit (either 0 or 315). _optional_
+
+- `--single.mig-profile=n`, where n is typically a value of int type between 0-5. The parameter is used to choose the MIG profile from list of available MIG profiles (e.g. 1g.5gb is usually referenced with index 0).  If not specified, a valid random number is used. Typically values 0-5. - *optional*
+- `--mixed.mig.instances=xxx`, where xxx is a comma-separated string inside quotation marks (e.g. "2,0,1,1,0,0") The list of numbers represent how many instances are to be used for each profile when creating a pod. The first number indicates how many instances are to be used for the first profile etc. The instances of different profiles consume GPU slices in a different way. The name of the profile (e.g. 2g.10gb) describes the consumption of each instance (each instance would consume 2 slices and 10gb of memory). *optional*
+- `--mixed.mig.pod-delay=n`, where n is a number in range 0 - 315 (seconds). In mixed MIG testcase there are usually more than 1 pod launched (depends on available GPU and mixed.mig.instances parameter). Since GPU workload is 300 seconds, this parameter can be used to control the delay between the pod launches so that the pods are running completely simultaneously, mostly overlapping (e.g. 15-80), slightly overlapping (e.g. 200-280 seconds), or non-overlapping (over 300 seconds). Values outside valid range are reset to closest limit (either 0 or 315). *optional*
+- --time.slicing.instances="n". Default is 8. There may be a comma-separated list of values, as many as pod-count indicates. The values indicate how many timeslices for each pod is to be created (e.g. "1,2,3,4,5,6,7,8", meaning that first pod would get 1 time-slice, second one would get 2, etc.). They may run simultaneously as long as they don't exceed the maximum value (8). Any pods that is not getting the resources will stay in pending state until the requested resources become available. Any pod with requested 8 time-slices will run alone. The sum of the values is currently restricted to 100.
+- --time.slicing.mon-after-pod=n. Default is 0, meaning that process monitoring will start immediately. If there are 5 instances and mon-after-pod=4, the process monitoring would only start after 4th pod. There may be previous pods still running depending on how many time-slices they have been allocated. Any number exceeding the number of instances will prevent the process monitoring
+
+
+
 
 ### Testing MPS with GPU Operator
 
@@ -127,6 +154,7 @@ It is recommended to execute the runner script through the `make run-tests` make
 #### Steps to run MPS tests:
 
 1. First, deploy the GPU Operator with cleanup disabled for example:
+
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
@@ -141,12 +169,15 @@ $ export NVIDIAGPU_SUBSCRIPTION_CHANNEL="v23.9"
 $ export NVIDIAGPU_CLEANUP=false  # Important: don't clean up after deployment
 $ make run-tests
 ```
-2. After the GPU Operator deployment completes successfully, run the MPS tests:
+
+1. After the GPU Operator deployment completes successfully, run the MPS tests:
+
 ```bash
 $ export TEST_FEATURES="mps"
 $ export TEST_LABELS='nvidia-ci,mps'  # Run MPS-specific tests
 $ make run-tests
 ```
+
 The MPS tests will use the existing GPU Operator deployment that was left in place from the previous test run. This ensures that the MPS tests can properly validate MPS functionality on an already configured GPU environment.
 
 #### Test Suite Ordering:
@@ -163,6 +194,7 @@ $ export TEST_LABELS='nvidia-ci,cleanup'
 $ export NVIDIAGPU_CLEANUP=true
 $ make run-tests
 ```
+
 This will remove all resources created by both the GPU Operator deployment and MPS tests.
 
 ### Testing MIG with GPU Operator
@@ -173,19 +205,22 @@ It is recommended to execute the runner script through the `make run-tests` make
 
 #### Steps to run MIG tests:
 
-1. Run mig testcases (single-mig and mixed-mig) after nvidia-ci on any cluster, while selecting single.mig.profile=1
+1. Run mig testcases (single-mig and mixed-mig) after nvidia-ci on any cluster, while selecting single.mig.profile=1 and 2 time-slicing pods, which do not run at the same time because their sum would exceed the maximum number of time-slices (8).
+
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
 $ export REPORTS_DUMP_DIR=/tmp/nvidia-ci-gpu-logs-dir
 $ export TEST_FEATURES="nvidiagpu"
-$ export TEST_LABELS='nvidia-ci,gpu,single-mig,mixed-mig'
+$ export TEST_LABELS='nvidia-ci,gpu,single-mig,mixed-mig,time-slicing'
 $ export TEST_TRACE=true
 $ export VERBOSE_LEVEL=100
 $ export NVIDIAGPU_CLEANUP=false
-$ make run-tests ARGS="-- --single.mig.profile=1"
+$ make run-tests ARGS="-- --single.mig.profile=1" --time.slicing.instances="3,8"
 ```
-2. Running only MIG testcases on an existing cluster which has GPU operator installed,
+
+1. Running only MIG testcases on an existing cluster which has GPU operator installed,
+
 e.g. after executing step 1. MIG testcase(s) can be used from either nvidiagpu or
 mig package. MIG is used in this example. In the other case, use `TEST_FEATURES="nvidiagpu"`
 to execute the testcase from nvidiagpu package.
@@ -193,23 +228,28 @@ With these MIG parameters single-mig testcase would choose a random MIG profile 
 included) , mixed-mig testcase would use 1 instance amount for A100 GPU (1x 1g.5gb, 1x 2g.10gb and 1x 3g.20gb,
 leaving the second profile 1g.10gb unused).
 mixed-mig testcase would wait 35 seconds between the pods launching with mixed.mig.pod-delay parameter
+time-slicing testcase would launch 8 pods, with 1 time-slice each, allowing them to be executed at the same time
 You can deliver the ginkgo cli parameter using ARGS after the "make run-tests"
+
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
 $ export REPORTS_DUMP_DIR=/tmp/nvidia-ci-gpu-logs-dir
 $ export TEST_FEATURES="mig"
-$ export TEST_LABELS='single-mig,mixed-mig'
+$ export TEST_LABELS='single-mig,mixed-mig,time-slicing'
 $ export TEST_TRACE=true
 $ export VERBOSE_LEVEL=100
 $ export NVIDIAGPU_CLEANUP=false
-$ make run-mig-tests ARGS="-- --mixed.mig.instances='1,0,1,1' --mixed.mig.pod-delay=35"
+$ make run-mig-tests ARGS="-- --mixed.mig.instances='1,0,1,1' --mixed.mig.pod-delay=35" --time.slicing.instances="1,1,1,1,1,1,1,1"
 ```
+
+
 
 #### Cleanup:
 
 If the GPU operator and gpu burn pod needs to be cleaned up, just set the cleanup parameter to true
 in the last execution of either steps 1 or 2
+
 ```bash
 $ export NVIDIAGPU_CLEANUP=true
 ```
@@ -234,12 +274,13 @@ $ make run-tests
 ### Examples of Testing GPU Operator end-to-end
 
 Example running the end-to-end GPU Operator test case:
+
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
 $ export REPORTS_DUMP_DIR=/tmp/nvidia-ci-gpu-logs-dir
 $ export TEST_FEATURES="nvidiagpu"
-$ export TEST_LABELS='nvidia-ci,gpu,single-mig,mixed-mig'
+$ export TEST_LABELS='nvidia-ci,gpu,single-mig,mixed-mig,time-slicing'
 $ export TEST_TRACE=true
 $ export VERBOSE_LEVEL=100
 $ export NVIDIAGPU_GPU_MACHINESET_INSTANCE_TYPE="g4dn.xlarge"
@@ -248,8 +289,10 @@ $ export NVIDIAGPU_SUBSCRIPTION_CHANNEL="v23.9"
 $ make run-tests
 Executing nvidiagpu test-runner script
 scripts/test-runner.sh
-ginkgo -timeout=24h --keep-going --require-suite -r -vv --trace --label-filter="nvidia-ci,gpu,single-mig,mixed-mig" ./tests/nvidiagpu
+ginkgo -timeout=24h --keep-going --require-suite -r -vv --trace --label-filter="nvidia-ci,gpu,single-mig,mixed-mig,time-slicing" ./tests/nvidiagpu
 ```
+
+
 
 ### Examples of Testing GPU Operator upgrade
 
@@ -257,6 +300,7 @@ Example running the GPU Operator upgrade testcase (from v23.6 to v24.3) after th
 Note:  you must run the end-to-end testcase first to deploy a previous version, set NVIDIAGPU_CLEANUP=false,
 and specify the channel to upgrade to NVIDIAGPU_SUBSCRIPTION_UPGRADE_TO_CHANNEL=v24.3, along with the label
 'operator-upgrade' in TEST_LABELS.  Otherwise, the upgrade testcase will not be executed:
+
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
@@ -276,10 +320,13 @@ scripts/test-runner.sh
 ginkgo -timeout=24h --keep-going --require-suite -r -vv --trace --label-filter="nvidia-ci,gpu,operator-upgrade" ./tests/nvidiagpu
 ```
 
+
+
 ### Example of running nvidia-ci with custom parameters for NFD and GPU operators
 
 Example running the end-to-end test case and creating custom catalogsources for NFD and GPU Operator packagmanifests
 when missing from their default catalogsources.
+
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
@@ -294,10 +341,13 @@ $ export NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE="registry.redhat.io/redhat/redha
 $ make run-tests
 ```
 
+
+
 ### Example for end-to-end Network Operator testcase with Legacy SRIOV RDMA testcase
 
 Example running the end-to-end Network Operator test case, with the Legacy SRIOV RDMA testcase.  
 Note: both TEST_LABELS "deploy || rdma-legacy-sriov' are specified in examples below:
+
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
 $ export DUMP_FAILED_TESTS=true
@@ -336,3 +386,4 @@ Executing nvidiagpu test-runner script
 scripts/test-runner.sh
 ginkgo -timeout=24h --keep-going --require-suite -r -vv --trace --label-filter="deploy || rdma-legacy-sriov" ./tests/nvidianetwork
 ```
+

--- a/internal/gpuburn/gpuburn.go
+++ b/internal/gpuburn/gpuburn.go
@@ -19,6 +19,7 @@ var (
 	isFalse bool = false
 	isTrue  bool = true
 
+	// Optional container args (e.g. time-slicing -m 12%) are appended after the fixed duration via "$@".
 	gpuBurnConfigMapData = map[string]string{
 		"entrypoint.sh": `#!/bin/bash
 		NUM_GPUS=$(nvidia-smi -L | wc -l)
@@ -26,7 +27,7 @@ var (
   			echo "ERROR No GPUs found"
 			exit 1
 		fi
-		./gpu_burn 300
+		./gpu_burn "$@" 300
 
 		if [ ! $? -eq 0 ]; then
 		  exit 1
@@ -71,9 +72,14 @@ func CreateGPUBurnPodWithMIG(apiClient *clients.Settings, podName, podNamespace 
 	// For single strategy MIGs, migProfile is "gpu" resulting in "nvidia.com/gpu".
 	// For other MIG profiles, migProfile is like "1g.5gb", and with required mig prefix: "nvidia.com/mig-1g.5gb".
 	var migResourceName string
+	var burnContainerArgs []string
 	switch migProfile {
 	case "gpu":
 		migResourceName = fmt.Sprintf("nvidia.com/%s", migProfile)
+	case "time-slicing":
+		migResourceName = "nvidia.com/gpu" // time-slicing uses gpu resource; pod Args forwarded by entrypoint.sh ("$@")
+		// burnContainerArgs = []string{"-m", "110%"}
+		burnContainerArgs = []string{"-m", "12%"}
 	default:
 		migResourceName = fmt.Sprintf("nvidia.com/mig-%s", migProfile)
 	}
@@ -118,6 +124,7 @@ func CreateGPUBurnPodWithMIG(apiClient *clients.Settings, podName, podNamespace 
 					Command: []string{
 						"/bin/entrypoint.sh",
 					},
+					Args: burnContainerArgs,
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceName(migResourceName): *resource.NewQuantity(int64(migCount), resource.DecimalSI),

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -141,36 +141,25 @@ func DeploymentCreated(apiClient *clients.Settings, deploymentName, deploymentNa
 	return err == nil
 }
 
-// NodeLabelExists waits for at least one node with the specified label selector to have a label with the given key and value.
+// NodeLabelExists waits for at least one node matching the nodeSelector to also have a label with the given key and value.
 func NodeLabelExists(apiClient *clients.Settings, labelKey, labelValue string, nodeSelector labels.Set, pollInterval,
 	timeout time.Duration) error {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("Waiting for node label '%s'='%s' on nodes with selector: %v", labelKey, labelValue, nodeSelector)
+	// Merge nodeSelector with the target label so the API returns only nodes that match both.
+	mergedSelector := make(labels.Set, len(nodeSelector)+1)
+	for k, v := range nodeSelector {
+		mergedSelector[k] = v
+	}
+	mergedSelector[labelKey] = labelValue
+
 	return wait.PollUntilContextTimeout(
 		context.TODO(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			nodeBuilders, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: nodeSelector.String()})
-
+			nodeBuilders, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: mergedSelector.String()})
 			if err != nil {
 				glog.V(gpuparams.GpuLogLevel).Infof("Error listing nodes: %v", err)
-
 				return false, err
 			}
-
-			for _, node := range nodeBuilders {
-				glog.V(gpuparams.Gpu10LogLevel).Infof("Checking node '%s' for label '%s'", node.Object.Name, labelKey)
-				if value, ok := node.Object.Labels[labelKey]; ok && value == labelValue {
-					glog.V(gpuparams.Gpu100LogLevel).Infof("Found label '%s' with value '%s' on node '%s'", labelKey, labelValue, node.Object.Name)
-
-					// this exits out of the PollUntilContextTimeout()
-					return true, nil
-				} else {
-					glog.V(gpuparams.Gpu10LogLevel).Infof("Label '%s'='%s' not found on node '%s'", labelKey, labelValue, node.Object.Name)
-					return false, nil
-				}
-			}
-
-			glog.V(gpuparams.Gpu10LogLevel).Infof("Label '%s'='%s' not found yet, retrying...", labelKey, labelValue)
-
-			return false, nil
+			return len(nodeBuilders) > 0, nil
 		})
 }
 

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -491,6 +491,7 @@ func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUCo
 	By("Create time-slicing config")
 	_, err = CreateTimeSlicingConfig(inittools.APIClient, workerNodeSelector, "", MaxTsSlices)
 	Expect(err).ToNot(HaveOccurred(), "error creating time-slicing config: %v", err)
+	timeSlicingSetupStarted = true
 
 	// Check and create test-gpu-burn namespace if it is missing
 	By("Create test-gpu-burn namespace")
@@ -550,6 +551,7 @@ func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUCo
 	status, pids := GetPidsFromPmon(output, 2)
 
 	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v with status: %s", pids, status)
+	Expect(len(pids)).To(Equal(0), "pre-test pmon check: expected no GPU compute pids before time-slicing test, got %v", pids)
 
 	By("Checking pre-testing time-slicing status, pid status for existing pids")
 	cmd = []string{"nvidia-smi", "--query-compute-apps=pid,process_name,used_memory,timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid", "--format=csv,nounits"}
@@ -563,9 +565,7 @@ func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUCo
 
 	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v with status: %s", pids, status)
 
-	status, podInfo := GetPodsWithPids(inittools.APIClient, workerNodeSelector, pids)
-	Expect(status).To(BeTrue(), "Error getting pod info: %v", err)
-	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod info: %v", podInfo)
+	GetPodsWithPids(inittools.APIClient, workerNodeSelector, pids)
 
 	By("Deploy gpu-burn pod with time-slicing in test-gpu-burn namespace")
 	var tsPodInfo []TsPodInfo
@@ -1139,9 +1139,6 @@ func CreateTimeSlicingConfig(apiClient *clients.Settings, workerNodeSelector map
 	glog.V(gpuparams.GpuLogLevel).Infof("Set ClusterPolicy %s spec.devicePlugin.config.name=%q default=%q",
 		nvidiagpu.ClusterPolicyName, timeSlicingDevicePluginConfigMapName, product)
 
-	if err := applyDevicePluginConfigNodeLabels(apiClient, out.Data, workerNodeSelector); err != nil {
-		return nil, err
-	}
 	return out, nil
 }
 
@@ -1728,9 +1725,9 @@ func isRunning(gpuPod *pod.Builder, namespace string) int {
 	// This is to avoid waiting, if the pod is already in Running or Succeeded phase.
 	// If pod was Completed (or Running) already, there's no need to wait.
 	// Avoiding the timeout in case it is Completed already is preferred.
-	_, err := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
+	pulledPod, err := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
 	Expect(err).ToNot(HaveOccurred(), "Pod %s does not exist in namespace %s with error: %v", gpuPod.Definition.Name, namespace, err)
-	switch gpuPod.Object.Status.Phase {
+	switch pulledPod.Object.Status.Phase {
 	case corev1.PodSucceeded:
 		return 0
 	case corev1.PodRunning:
@@ -1895,9 +1892,7 @@ func MonitorTimeslicingGPULoad(burn *nvidiagpu.GPUBurnConfig, podInfo TsPodInfo,
 		glog.V(gpuparams.GpuLogLevel).Infof("\ntime-slicing monitor: nvidia-smi CSV:\n%s\n",
 			outCSV)
 
-		status, podInfo := GetPodsWithPids(inittools.APIClient, workerNodeSelector, pids)
-		Expect(status).To(BeTrue(), "Error getting pod info: %v", err)
-		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod info: %v", podInfo)
+		GetPodsWithPids(inittools.APIClient, workerNodeSelector, pids)
 	}
 	time.Sleep(pollInterval)
 }
@@ -2308,19 +2303,13 @@ func GetPidsFromPmon(output string, index int) (bool, []int) {
 	})
 }
 
-type PodInfo struct {
-	PodName string
-}
 
-func GetPodsWithPids(apiClient *clients.Settings, nodeSelector map[string]string, pids []int) (bool, []PodInfo) {
-	glog.V(gpuparams.Gpu100LogLevel).Infof("GetPodsWithPids")
-	// var podInfo []PodInfo
-	// return true, []PodInfo(PodInfo{PodName: "pod1", pid: 1})
+func GetPodsWithPids(apiClient *clients.Settings, nodeSelector map[string]string, pids []int) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "GetPidsWithRegex"))
 	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v", pids)
 	for _, pid := range pids {
 		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pid: %d", pid)
 		podName := fmt.Sprintf("pod-%d", pid)
 		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod name: %s", podName)
 	}
-	return true, []PodInfo{}
 }

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -619,7 +619,7 @@ func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUCo
 			if podInfo.Pod.Exists() {
 				// skip if the pod was failed, testcase collects logs for the pods anyway
 				ret := isFailed(podInfo.Pod, podInfo.Namespace)
-				if ret == true {
+				if ret {
 					continue
 				}
 				ret1 := isRunning(podInfo.Pod, podInfo.Namespace)
@@ -643,7 +643,7 @@ func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUCo
 	for _, podInfo := range tsPodInfo {
 		if podInfo.Pod.Exists() {
 			ret := isFailed(podInfo.Pod, podInfo.Namespace)
-			if ret == true {
+			if ret {
 				continue
 			}
 			isCompleted(podInfo.Pod, podInfo.Namespace)
@@ -1159,7 +1159,7 @@ func updateTimeSlicingDevicePluginConfigMap(apiClient *clients.Settings, gpuProd
 		},
 		Data: data,
 	}
-	cms := apiClient.CoreV1Interface.ConfigMaps(ns)
+	cms := apiClient.ConfigMaps(ns)
 	created, err := cms.Create(context.TODO(), cm, metav1.CreateOptions{})
 	if err == nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Created ConfigMap %s/%s for device-plugin time-slicing", ns, timeSlicingDevicePluginConfigMapName)
@@ -1215,7 +1215,7 @@ func captureTimeSlicingConfigSnapshot(apiClient *clients.Settings) (*timeSlicing
 	}
 
 	ns := nvidiagpu.NvidiaGPUNamespace
-	existing, getErr := apiClient.CoreV1Interface.ConfigMaps(ns).Get(
+	existing, getErr := apiClient.ConfigMaps(ns).Get(
 		context.TODO(), timeSlicingDevicePluginConfigMapName, metav1.GetOptions{})
 	if getErr == nil {
 		snap.configMapExisted = true
@@ -1254,7 +1254,7 @@ func removeDevicePluginConfigNodeLabels(apiClient *clients.Settings, nodeSelecto
 func restoreTimeSlicingDevicePluginConfigMap(apiClient *clients.Settings, snap *timeSlicingConfigSnapshot) error {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "restoreTimeSlicingDevicePluginConfigMap"))
 	ns := nvidiagpu.NvidiaGPUNamespace
-	cms := apiClient.CoreV1Interface.ConfigMaps(ns)
+	cms := apiClient.ConfigMaps(ns)
 
 	if !snap.configMapExisted {
 		err := cms.Delete(context.TODO(), timeSlicingDevicePluginConfigMapName, metav1.DeleteOptions{})
@@ -1735,6 +1735,11 @@ func isRunning(gpuPod *pod.Builder, namespace string) int {
 		return 0
 	case corev1.PodRunning:
 		return 1
+	case corev1.PodPending, corev1.PodUnknown:
+		// fall through to WaitUntilInStatus
+	case corev1.PodFailed:
+		isFailed(gpuPod, namespace)
+		return 3
 	}
 
 	// Waiting for the pod to reach Running phase, if it was not already.
@@ -1863,8 +1868,9 @@ func MonitorTimeslicingGPULoad(burn *nvidiagpu.GPUBurnConfig, podInfo TsPodInfo,
 		activePendingOrRunning = true
 	case corev1.PodSucceeded:
 		By(fmt.Sprintf("Completed pod %s", name))
-	default:
-		// PodUnknown, etc. — treat as still in progress
+	case corev1.PodFailed:
+		// isFailed already called above
+	case corev1.PodUnknown:
 		activePendingOrRunning = true
 	}
 
@@ -2302,10 +2308,8 @@ func GetPidsFromPmon(output string, index int) (bool, []int) {
 	})
 }
 
-// pid vs pod
 type PodInfo struct {
 	PodName string
-	pid     int
 }
 
 func GetPodsWithPids(apiClient *clients.Settings, nodeSelector map[string]string, pids []int) (bool, []PodInfo) {

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -657,6 +657,12 @@ func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUCo
 		if podInfo.Pod.Exists() {
 			// Second parameter guides on how old logs can be retrieved.
 			gpuBurnMigLogs := GetGPUBurnPodLogs(podInfo.Pod, maxPodIndex-i)
+			if strings.TrimSpace(gpuBurnMigLogs) == "" {
+				fullLogs, err := podInfo.Pod.GetFullLog("gpu-burn-ctr")
+				Expect(err).ToNot(HaveOccurred(), "error getting full gpu-burn logs for %s: %v",
+					podInfo.Pod.Definition.Name, err)
+				gpuBurnMigLogs = fullLogs
+			}
 			// CheckGPUBurnPodLogs(gpuBurnMigLogs, 1) // only 1 GPU used for time-slicing
 			CheckTimeSlicingGPUBurnPodLogs(gpuBurnMigLogs)
 		}

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+
+	// "os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -31,8 +33,11 @@ import (
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/olm"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/pod"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	// "sigs.k8s.io/yaml"
 )
 
 // TestSingleMIGGPUBurn performs the GPU Burn test with single strategy MIG Configuration
@@ -437,6 +442,232 @@ func TestMixedMIGGPUWorkload(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUConfig, b
 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorGreen+colorBold, "Mixed MIG Test completed"))
 }
 
+func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUConfig, burn *nvidiagpu.GPUBurnConfig,
+	burnImageName map[string]string, workerNodeSelector map[string]string, cleanupAfterTest bool) {
+
+	By("Read and validate time.slicing.instances")
+	_ = ReadTimeSlicingParameters()
+
+	// ***** Cleaning up previous GPU Burn resources
+	By("Cleanup if necessary")
+	CleanupWorkloadResources(burn)
+
+	By("Disable MIG if configured on GPU nodes")
+	migActive, err := IsMig(workerNodeSelector)
+	Expect(err).ToNot(HaveOccurred(), "error checking MIG status on GPU nodes: %v", err)
+	if migActive {
+		DisableMig(workerNodeSelector)
+	}
+
+	tsConfigSnap, err := captureTimeSlicingConfigSnapshot(inittools.APIClient)
+	Expect(err).ToNot(HaveOccurred(), "error capturing time-slicing config snapshot: %v", err)
+
+	timeSlicingSetupStarted := false
+	defer func() {
+		defer GinkgoRecover()
+		if !timeSlicingSetupStarted {
+			return
+		}
+		alreadyFailed := CurrentSpecReport().Failed()
+		waitForReady := !alreadyFailed
+
+		glog.V(gpuparams.Gpu100LogLevel).Infof("defer (remove time-slicing config)")
+		if err := DeletePods(inittools.APIClient, burn.Namespace).
+			WithLabelSelector(burn.PodLabel).
+			Delete(); err != nil {
+			glog.Errorf("time-slicing teardown: delete gpu-burn pods: %v", err)
+			if !alreadyFailed {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+		if err := removeTimeSlicingConfig(inittools.APIClient, workerNodeSelector, tsConfigSnap, waitForReady); err != nil {
+			glog.Errorf("time-slicing teardown: remove config: %v", err)
+			if !alreadyFailed {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+	}()
+
+	By("Create time-slicing config")
+	_, err = CreateTimeSlicingConfig(inittools.APIClient, workerNodeSelector, "", MaxTsSlices)
+	Expect(err).ToNot(HaveOccurred(), "error creating time-slicing config: %v", err)
+
+	// Check and create test-gpu-burn namespace if it is missing
+	By("Create test-gpu-burn namespace")
+	gpuBurnNsBuilder := namespace.NewBuilder(inittools.APIClient, burn.Namespace)
+	if !gpuBurnNsBuilder.Exists() {
+		glog.V(gpuparams.Gpu10LogLevel).Infof("Creating the gpu burn namespace '%s'", burn.Namespace)
+		_, err = gpuBurnNsBuilder.Create()
+		Expect(err).ToNot(HaveOccurred(), "error creating gpu burn "+
+			"namespace '%s' : %v ", burn.Namespace, err)
+	}
+
+	// GPU burn entrypoint ConfigMap (CleanupWorkloadResources removed it); same name/namespace as other MIG tests.
+	By("Deploy GPU Burn configmap for time-slicing in test-gpu-burn namespace")
+	gpuBurnEntryCmBuilder := configmap.NewBuilder(inittools.APIClient, burn.ConfigMapName, burn.Namespace)
+	if !gpuBurnEntryCmBuilder.Exists() {
+		glog.V(gpuparams.Gpu10LogLevel).Infof("Creating the gpu burn configmap '%s' in namespace '%s'",
+			burn.ConfigMapName, burn.Namespace)
+		_, err = gpuburn.CreateGPUBurnConfigMap(inittools.APIClient, burn.ConfigMapName, burn.Namespace)
+		Expect(err).ToNot(HaveOccurred(), "Error Creating gpu burn configmap: %v", err)
+	}
+
+	gpuBurnEntryCmBuilder, err = configmap.Pull(inittools.APIClient, burn.ConfigMapName, burn.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "Error pulling gpu-burn configmap '%s' from "+
+		"namespace '%s': %v", burn.ConfigMapName, burn.Namespace, err)
+
+	defer func() {
+		defer GinkgoRecover()
+		glog.V(gpuparams.Gpu100LogLevel).Infof("defer (gpu-burn entrypoint configmap for time-slicing) deleting configmap")
+		if cleanupAfterTest {
+			err := gpuBurnEntryCmBuilder.Delete()
+			Expect(err).ToNot(HaveOccurred(), "Error deleting gpu-burn configmap: %v", err)
+			err = gpuBurnEntryCmBuilder.WaitUntilDeleted(15 * time.Second)
+			Expect(err).ToNot(HaveOccurred(), "Error waiting for gpu-burn configmap to be deleted: %v", err)
+		}
+	}()
+
+	// CreateTimeSlicingConfig already enables GFD and updates ClusterPolicy; avoid a second Update here
+	// (stale resourceVersion can trigger delete/recreate in clusterpolicy.go).
+	By("Get cluster architecture from GPU worker nodes")
+	clusterArch, err := get.GetClusterArchitecture(inittools.APIClient, workerNodeSelector)
+	Expect(err).ToNot(HaveOccurred(), "error getting cluster architecture: %v", err)
+	glog.V(gpuparams.Gpu10LogLevel).Infof("Cluster architecture: %v", clusterArch)
+
+	By("Checking pre-testing time-slicing status, no pids should be found")
+	cmd := []string{"nvidia-smi", "pmon", "-d", "5", "-c", "5"}
+	// 	# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command
+	// # Idx           #    C/G      %      %      %      %      %      %    name
+	//     0    1020701     C     19      1      -      -      -      -    gpu_burn
+	//     0    1020782     C     11      0      -      -      -      -    gpu_burn
+	//     0    1020845     C     11      0      -      -      -      -    gpu_burn
+	//     0    1020858     C      7      0      -      -      -      -    gpu_burn
+	//     0    1020869     C      7      0      -      -      -      -    gpu_burn
+
+	output := GetCmdOutput(inittools.APIClient, workerNodeSelector, cmd)
+	Expect(output).NotTo(BeEmpty(), "Error checking time-slicing status: %v", err)
+	// Get the PID (1st column) from the CSV output
+	status, pids := GetPidsFromPmon(output, 2)
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v with status: %s", pids, status)
+
+	By("Checking pre-testing time-slicing status, pid status for existing pids")
+	cmd = []string{"nvidia-smi", "--query-compute-apps=pid,process_name,used_memory,timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid", "--format=csv,nounits"}
+	// 909847, ./gpu_burn, 36268 MiB, 2026/03/02 10:48:43.256, NVIDIA A100-PCIE-40GB, 00000000:B1:00.0, 1323720014180, GPU-ea8148c0-9fd4-3e84-18a0-19cffe1cecce
+	// 909855, ./gpu_burn, 3756 MiB, 2026/03/02 10:48:43.256, NVIDIA A100-PCIE-40GB, 00000000:B1:00.0, 1323720014180, GPU-ea8148c0-9fd4-3e84-18a0-19cffe1cecce
+
+	output = GetCmdOutput(inittools.APIClient, workerNodeSelector, cmd)
+	Expect(output).NotTo(BeEmpty(), "Error checking time-slicing status: %v", err)
+	// Get the PID (1st column) from the CSV output
+	status, pids = GetPidFromCSV(output, 1)
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v with status: %s", pids, status)
+
+	status, podInfo := GetPodsWithPids(inittools.APIClient, workerNodeSelector, pids)
+	Expect(status).To(BeTrue(), "Error getting pod info: %v", err)
+	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod info: %v", podInfo)
+
+	By("Deploy gpu-burn pod with time-slicing in test-gpu-burn namespace")
+	var tsPodInfo []TsPodInfo
+	// pods := make([]*pod.Builder, 0, TsPodCount)
+	for i := 0; i < TsPodCount; i++ {
+		slices := TsInstances[i]
+		podName := fmt.Sprintf("gpu-burn-pod-%d-slice-%d", i+1, slices)
+		glog.V(gpuparams.Gpu10LogLevel).Infof("Creating time-slicing gpu-burn pod %s requesting nvidia.com/gpu=%d",
+			podName, slices)
+		pb := DeployGPUWorkload(burnImageName[clusterArch], podName, burn.Namespace, "time-slicing", slices, burn.PodLabel)
+		tsPodInfo = append(tsPodInfo, TsPodInfo{
+			PodName:   podName,
+			Namespace: burn.Namespace,
+			Pod:       pb,
+			Checked:   false,
+		})
+	}
+	// allow pods to get into Running state to avoid unnecessary logging
+	time.Sleep(10 * time.Second)
+
+	// Ensure all pods get into Running state, looping through the previously created & collected pods.
+	// Competed status is accepted as well in the isRunning function (because of mixed.mig.pod-delay parameter,
+	//   previous pods may be completed while the later ones are still running).
+	By("Ensure required number of pods get into Running state")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Ensure required number of pods get into Running state before starting monitoring"))
+	i := 0
+	for _, podInfo := range tsPodInfo {
+		if TsMonAfterPod <= i {
+			glog.V(gpuparams.GpuLogLevel).Infof("Monitoring will now start after %v pods reached running state", TsMonAfterPod)
+			break
+		}
+		if podInfo.Pod.Exists() {
+			isRunning(podInfo.Pod, podInfo.Namespace)
+		}
+		i++
+	}
+
+	By("Monitor time-slicing status until all gpu-burn pods complete; validate each pod log on success")
+	if TsMonAfterPod <= len(tsPodInfo) {
+		j := 0
+		for _, podInfo := range tsPodInfo {
+			j++
+			if j < TsMonAfterPod {
+				// skipping pods before time-slicing.mon-after-pod
+				glog.V(gpuparams.Gpu10LogLevel).Infof("Skipping pod %s/%s before time-slicing.mon-after-pod", podInfo.Namespace, podInfo.Pod.Definition.Name)
+				continue
+			} else {
+				glog.V(gpuparams.Gpu10LogLevel).Infof("Monitoring pod %s/%s after time-slicing.mon-after-pod", podInfo.Namespace, podInfo.Pod.Definition.Name)
+			}
+
+			if podInfo.Pod.Exists() {
+				// skip if the pod was failed, testcase collects logs for the pods anyway
+				ret := isFailed(podInfo.Pod, podInfo.Namespace)
+				if ret == true {
+					continue
+				}
+				ret1 := isRunning(podInfo.Pod, podInfo.Namespace)
+				if ret1 > 1 { // monitor once, and wait until pod is completed
+					// skip if the pod was already succeeded
+					MonitorTimeslicingGPULoad(burn, podInfo, workerNodeSelector)
+					// pmonOut := GetCmdOutput(inittools.APIClient, workerNodeSelector, []string{"nvidia-smi", "pmon", "-d", "1", "-c", "1"})
+					// status, pids := GetPidsFromPmon(pmonOut, 2)
+					// glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v with status: %v", pids, status)
+					isCompleted(podInfo.Pod, burn.Namespace)
+				}
+			}
+		}
+	} else {
+		glog.V(gpuparams.GpuLogLevel).Infof("No monitoring, parameter mon-after-pod: %v is bigger than the number of pods: %v", TsMonAfterPod, len(tsPodInfo))
+	}
+
+	// Waiting until the pods are completed (or failed). Depending on the delay between the pods, this may take some time in each iteration.
+	By("Wait for GPU Burn pods to complete")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Wait for GPU Burn pods to complete"))
+	for _, podInfo := range tsPodInfo {
+		if podInfo.Pod.Exists() {
+			ret := isFailed(podInfo.Pod, podInfo.Namespace)
+			if ret == true {
+				continue
+			}
+			isCompleted(podInfo.Pod, podInfo.Namespace)
+		}
+	}
+
+	// After all pods are completed, get and check the logs for each pod.
+	// The log retrieval has a validity time period. Second parameter is a multiplier to calculate the validity time.
+	By("Get and check the gpu-burn pod logs")
+	maxPodIndex := len(tsPodInfo) - 1
+	i = 0
+	for _, podInfo := range tsPodInfo {
+		if podInfo.Pod.Exists() {
+			// Second parameter guides on how old logs can be retrieved.
+			gpuBurnMigLogs := GetGPUBurnPodLogs(podInfo.Pod, maxPodIndex-i)
+			// CheckGPUBurnPodLogs(gpuBurnMigLogs, 1) // only 1 GPU used for time-slicing
+			CheckTimeSlicingGPUBurnPodLogs(gpuBurnMigLogs)
+		}
+		i++
+	}
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorGreen+colorBold, "Time-slicing Test completed"))
+
+}
+
 // CleanupGPUOperatorResources performs cleanup of GPU Operator resources
 // It checks if cleanup should run based on cleanupAfterTest and cleanup label
 func CleanupGPUOperatorResources(cleanupAfterTest bool, burnNamespace string) {
@@ -460,7 +691,7 @@ func CleanupGPUOperatorResources(cleanupAfterTest bool, burnNamespace string) {
 
 // cleanupClusterPolicy deletes the ClusterPolicy resource if it exists
 func cleanupClusterPolicy() {
-	By("Deleting ClusterPolicy")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Delete ClusterPolicy"))
 	clusterPolicyBuilder, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
 	if err == nil && clusterPolicyBuilder.Exists() {
 		_, err := clusterPolicyBuilder.Delete()
@@ -473,7 +704,7 @@ func cleanupClusterPolicy() {
 
 // cleanupCSV deletes the ClusterServiceVersion resources if they exist
 func cleanupCSV() {
-	By("Deleting CSV")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Delete CSV"))
 	csvList, err := olm.ListClusterServiceVersion(inittools.APIClient, nvidiagpu.SubscriptionNamespace)
 	if err == nil && len(csvList) > 0 {
 		for _, csv := range csvList {
@@ -488,7 +719,7 @@ func cleanupCSV() {
 
 // cleanupSubscription deletes the Subscription resource if it exists
 func cleanupSubscription() {
-	By("Deleting Subscription")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Delete Subscription"))
 	subBuilder, err := olm.PullSubscription(inittools.APIClient, nvidiagpu.SubscriptionName, nvidiagpu.SubscriptionNamespace)
 	if err == nil && subBuilder.Exists() {
 		err := subBuilder.Delete()
@@ -499,7 +730,7 @@ func cleanupSubscription() {
 
 // cleanupOperatorGroup deletes the OperatorGroup resource if it exists
 func cleanupOperatorGroup() {
-	By("Deleting OperatorGroup")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Delete OperatorGroup"))
 	ogBuilder, err := olm.PullOperatorGroup(inittools.APIClient, nvidiagpu.OperatorGroupName, nvidiagpu.SubscriptionNamespace)
 	if err == nil && ogBuilder.Exists() {
 		err := ogBuilder.Delete()
@@ -510,7 +741,7 @@ func cleanupOperatorGroup() {
 
 // cleanupGPUOperatorNamespace deletes the GPU Operator namespace if it exists
 func cleanupGPUOperatorNamespace() {
-	By("Deleting GPU Operator Namespace")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Delete GPU Operator Namespace"))
 	nsBuilder := namespace.NewBuilder(inittools.APIClient, nvidiagpu.SubscriptionNamespace)
 	if nsBuilder.Exists() {
 		err := nsBuilder.Delete()
@@ -521,7 +752,7 @@ func cleanupGPUOperatorNamespace() {
 
 // cleanupGPUBurnNamespace deletes the GPU Burn namespace if it exists
 func cleanupGPUBurnNamespace(burnNamespace string) {
-	By("Deleting GPU Burn Namespace")
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Delete GPU Burn Namespace"))
 	burnNsBuilder := namespace.NewBuilder(inittools.APIClient, burnNamespace)
 	if burnNsBuilder.Exists() {
 		err := burnNsBuilder.Delete()
@@ -533,6 +764,7 @@ func cleanupGPUBurnNamespace(burnNamespace string) {
 // IsLabelInFilter checks if a specific label is present in the Ginkgo label filter from command line.
 // Returns true if the label is found in the filter, false otherwise.
 func IsLabelInFilter(label string) bool {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "IsLabelInFilter"))
 	filterQuery := GinkgoLabelFilter()
 	glog.V(gpuparams.Gpu100LogLevel).Infof("Checking if label '%s' is present in Ginkgo label filter: %s", label, filterQuery)
 
@@ -615,6 +847,7 @@ func ReadMIGParameter() []int {
 // ReadDelayBetweenPods returns the value of mixed.mig.pod-delay.
 // ReadDelayBetweenPods checks the Ginkgo CLI parameter mixed.mig.pod-delay and returns the value.
 func ReadDelayBetweenPods() int {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "ReadDelayBetweenPods"))
 	var podDelay int
 	switch {
 	case PodDelay < 0:
@@ -629,29 +862,39 @@ func ReadDelayBetweenPods() int {
 	return podDelay
 }
 
+// ReadTimeSlicingParameters parses and validates and validates --time.slicing.instances
+// and --time.slicing.mon-after-pod parameters.
+// It sets global TsInstances to the first TsPodCount slice counts (time slices requested per pod).
+func ReadTimeSlicingParameters() []int {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Validate time-slicing CLI parameters"))
+
+	parsed := parseMigInstances(TsInstancesCSV, defaultTsInstancesCSV)
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s %d", colorLog(colorCyan+colorBold, "parsed length"), len(parsed))
+	TsPodCount = len(parsed)
+
+	out := make([]int, TsPodCount)
+	copy(out, parsed[:TsPodCount])
+
+	sum := 0
+	for i, v := range out {
+		Expect(v).To(BeNumerically(">=", 0),
+			"time.slicing.instances value at index %d must be non-negative (got %d)", i, v)
+		sum += v
+	}
+	Expect(sum).To(BeNumerically("<=", MaxTsInstance),
+		"sum of time-slicing instance counts %v is %d; must not exceed %d", out, sum, MaxTsInstance)
+
+	TsInstances = out
+	glog.V(gpuparams.Gpu10LogLevel).Infof("Time-slicing: pod-count=%d per-pod instances=%v sum=%d (max=%d), mon-after-pod=%d",
+		TsPodCount, out, sum, MaxTsInstance, TsMonAfterPod)
+	return out
+}
+
 // CleanupWorkloadResources cleans up existing GPU burn pods and configmaps, then waits for cleanup to complete.
 func CleanupWorkloadResources(burn *nvidiagpu.GPUBurnConfig) {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Cleaning up namespace and workload resources"))
-	// Delete any existing gpu-burn pods with the label. There may be none.
-	podList, err := pod.List(inittools.APIClient, burn.Namespace, metav1.ListOptions{LabelSelector: burn.PodLabel})
-	switch {
-	case err != nil:
-		glog.V(gpuparams.Gpu10LogLevel).Infof("Error listing pods with label '%s': %v", burn.PodLabel, err)
-	case len(podList) > 0:
-		glog.V(gpuparams.GpuLogLevel).Infof("Found %d gpu-burn pod(s) with label '%s'", len(podList), burn.PodLabel)
-		for _, podBuilder := range podList {
-			glog.V(gpuparams.GpuLogLevel).Infof("Deleting gpu-burn pod '%s'", podBuilder.Definition.Name)
-			_, err = podBuilder.Delete()
-			Expect(err).ToNot(HaveOccurred(), "Error deleting workload pod '%s': %v", podBuilder.Definition.Name, err)
-		}
-		// Wait for all pods to be deleted
-		for _, podBuilder := range podList {
-			err = podBuilder.WaitUntilDeleted(30 * time.Second)
-			Expect(err).ToNot(HaveOccurred(), "Error waiting for workload pod '%s' to be deleted: %v", podBuilder.Definition.Name, err)
-		}
-		glog.V(gpuparams.Gpu10LogLevel).Infof("All gpu-burn pods with label '%s' have been deleted", burn.PodLabel)
-	default:
-		glog.V(gpuparams.Gpu10LogLevel).Infof("No gpu-burn pods found with label '%s'", burn.PodLabel)
+	if err := DeletePods(inittools.APIClient, burn.Namespace).WithLabelSelector(burn.PodLabel).Delete(); err != nil {
+		Expect(err).ToNot(HaveOccurred(), "Error deleting gpu-burn pods: %v", err)
 	}
 
 	// Delete the configmap if it exists
@@ -663,6 +906,455 @@ func CleanupWorkloadResources(burn *nvidiagpu.GPUBurnConfig) {
 		err = existingConfigmapBuilder.WaitUntilDeleted(30 * time.Second)
 		Expect(err).ToNot(HaveOccurred(), "Error waiting for workload configmap to be deleted: %v", err)
 	}
+}
+
+const defaultPodDeleteWait = 30 * time.Second
+
+// PodCleanup deletes pods in a namespace that match a label selector.
+type PodCleanup struct {
+	apiClient     *clients.Settings
+	namespace     string
+	labelSelector string
+	waitTimeout   time.Duration
+}
+
+// DeletePods starts a pod cleanup for the given namespace.
+func DeletePods(apiClient *clients.Settings, namespace string) *PodCleanup {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "DeletePods"))
+	return &PodCleanup{
+		apiClient:   apiClient,
+		namespace:   namespace,
+		waitTimeout: defaultPodDeleteWait,
+	}
+}
+
+// WithLabel adds a label requirement (key=value) to the pod label selector.
+func (p *PodCleanup) WithLabel(labelKey, labelValue string) *PodCleanup {
+	add := labelKey + "=" + labelValue
+	if p.labelSelector == "" {
+		p.labelSelector = add
+	} else {
+		p.labelSelector = p.labelSelector + "," + add
+	}
+	return p
+}
+
+// WithLabelSelector sets the pod label selector directly (e.g. "app=gpu-burn-app").
+func (p *PodCleanup) WithLabelSelector(labelSelector string) *PodCleanup {
+	p.labelSelector = labelSelector
+	return p
+}
+
+// Delete lists matching pods, deletes them, and waits until they are gone.
+func (p *PodCleanup) Delete() error {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, " Deleting all previously selected pods"))
+	if p.apiClient == nil {
+		return fmt.Errorf("pod cleanup apiClient is nil")
+	}
+	if p.namespace == "" {
+		return fmt.Errorf("pod cleanup namespace is empty")
+	}
+	if p.labelSelector == "" {
+		return fmt.Errorf("pod cleanup label selector is empty")
+	}
+
+	podList, err := pod.List(p.apiClient, p.namespace, metav1.ListOptions{LabelSelector: p.labelSelector})
+	if err != nil {
+		return fmt.Errorf("list pods in namespace %s with label selector %q: %w", p.namespace, p.labelSelector, err)
+	}
+	if len(podList) == 0 {
+		glog.V(gpuparams.Gpu10LogLevel).Infof("No pods found in namespace %s with label selector %q", p.namespace, p.labelSelector)
+		return nil
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Found %d pod(s) in namespace %s with label selector %q", len(podList), p.namespace, p.labelSelector)
+	for _, podBuilder := range podList {
+		glog.V(gpuparams.GpuLogLevel).Infof("Deleting pod %q", podBuilder.Definition.Name)
+		if _, err := podBuilder.Delete(); err != nil {
+			return fmt.Errorf("delete pod %s/%s: %w", p.namespace, podBuilder.Definition.Name, err)
+		}
+	}
+	for _, podBuilder := range podList {
+		if err := podBuilder.WaitUntilDeleted(p.waitTimeout); err != nil {
+			return fmt.Errorf("wait for pod %s/%s deletion: %w", p.namespace, podBuilder.Definition.Name, err)
+		}
+	}
+	glog.V(gpuparams.GpuLogLevel).Infof("All pods in namespace %s with label selector %q have been deleted", p.namespace, p.labelSelector)
+	return nil
+}
+
+// baseGPUProductName returns the stable device-plugin ConfigMap key: GFD may suffix gpu.product with -SHARED
+// after time-slicing is active, but device-plugin.config and ConfigMap keys must not use that suffix.
+func baseGPUProductName(product string) string {
+	return strings.TrimSuffix(strings.TrimSpace(product), gpuProductSharedSuffix)
+}
+
+// timeSlicingDevicePluginConfigData returns optional static ConfigMap entries (per-GPU keys are added via tsDPCD).
+func timeSlicingDevicePluginConfigData() map[string]string {
+	return map[string]string{}
+}
+
+// tsDPCD returns a minimal device-plugin ConfigMap .data fragment for time-slicing: only nvidia.com/gpu with the given replica count (no MIG entries).
+// gpuProduct must be a base product name (no -SHARED suffix); it becomes the ConfigMap data key and device-plugin.config label value.
+func tsDPCD(gpuProduct string, replicas int) map[string]string {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Returns minimal device-plugin ConfigMap"))
+	if gpuProduct == "" || replicas <= 0 {
+		return nil
+	}
+	yaml := fmt.Sprintf(`version: v1
+sharing:
+  timeSlicing:
+    resources:
+      - name: nvidia.com/gpu
+        replicas: %d
+`, replicas)
+	return map[string]string{gpuProduct: yaml}
+}
+
+func firstGPUProductFromNodes(apiClient *clients.Settings, nodeSelector map[string]string) string {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "firstGPUProductFromNodes"))
+	nodeBuilders, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: labels.Set(nodeSelector).String()})
+	if err != nil || len(nodeBuilders) == 0 {
+		return ""
+	}
+	for _, nb := range nodeBuilders {
+		if nb.Definition.Labels == nil {
+			continue
+		}
+		if v := nb.Definition.Labels[gpuProductLabelKey]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func waitForGPUProductLabel(apiClient *clients.Settings, nodeSelector map[string]string, poll, timeout time.Duration) (string, error) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "waitForGPUProductLabel"))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if p := firstGPUProductFromNodes(apiClient, nodeSelector); p != "" {
+			return p, nil
+		}
+		time.Sleep(poll)
+	}
+	return "", fmt.Errorf("timeout after %v waiting for label %s on nodes matching %v",
+		timeout, gpuProductLabelKey, nodeSelector)
+}
+
+// applyDevicePluginConfigNodeLabels sets nvidia.com/device-plugin.config to the stable ConfigMap key on GPU
+// worker nodes. Nodes are matched when base(nvidia.com/gpu.product) equals the ConfigMap key, so labeling
+// works whether or not GFD has already appended -SHARED to gpu.product.
+func applyDevicePluginConfigNodeLabels(apiClient *clients.Settings, cmData map[string]string, nodeSelector map[string]string) error {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "applyDevicePluginConfigNodeLabels"))
+	const devicePluginConfigLabel = "nvidia.com/device-plugin.config"
+
+	nodeBuilders, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: labels.Set(nodeSelector).String()})
+	if err != nil {
+		return fmt.Errorf("list nodes matching %v: %w", nodeSelector, err)
+	}
+	for _, nb := range nodeBuilders {
+		if nb.Definition.Labels == nil {
+			continue
+		}
+		gpuProduct := nb.Definition.Labels[gpuProductLabelKey]
+		if gpuProduct == "" {
+			glog.V(gpuparams.GpuLogLevel).Infof("Node %s has no %s label; skipping %s",
+				nb.Definition.Name, gpuProductLabelKey, devicePluginConfigLabel)
+			continue
+		}
+		configKey := baseGPUProductName(gpuProduct)
+		if _, ok := cmData[configKey]; !ok {
+			glog.V(gpuparams.GpuLogLevel).Infof("Node %s %s=%q (base %q) has no device-plugin ConfigMap entry; skipping %s",
+				nb.Definition.Name, gpuProductLabelKey, gpuProduct, configKey, devicePluginConfigLabel)
+			continue
+		}
+		nb = nb.WithLabel(devicePluginConfigLabel, configKey)
+		if _, err := nb.Update(); err != nil {
+			return fmt.Errorf("label node %s with %s=%s: %w", nb.Definition.Name, devicePluginConfigLabel, configKey, err)
+		}
+		glog.V(gpuparams.GpuLogLevel).Infof("Labeled node %s: %s=%s (%s=%q)",
+			nb.Definition.Name, devicePluginConfigLabel, configKey, gpuProductLabelKey, gpuProduct)
+	}
+	return nil
+}
+
+// CreateTimeSlicingConfig enables GFD, creates/updates the device-plugin ConfigMap and node labels, then sets
+// ClusterPolicy spec.devicePlugin.config (name + default). ConfigMap and labels are applied before the device-plugin
+// config reference is set so daemonset pods do not start with an empty nvidia.com/device-plugin.config label.
+func CreateTimeSlicingConfig(apiClient *clients.Settings, workerNodeSelector map[string]string, gpuProduct string, replicas int) (*corev1.ConfigMap, error) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "CreateTimeSlicingConfig"))
+	if replicas <= 0 {
+		return nil, fmt.Errorf("time-slicing replicas must be > 0, got %d", replicas)
+	}
+	if len(workerNodeSelector) == 0 {
+		return nil, fmt.Errorf("workerNodeSelector must not be empty (needed to discover %s when gpuProduct is empty)", gpuProductLabelKey)
+	}
+
+	cpBuilder, err := nvidiagpu.Pull(apiClient, nvidiagpu.ClusterPolicyName)
+	if err != nil {
+		return nil, fmt.Errorf("pull ClusterPolicy %s: %w", nvidiagpu.ClusterPolicyName, err)
+	}
+	gfdEnabled := true
+	cpBuilder.Definition.Spec.GPUFeatureDiscovery.Enabled = &gfdEnabled
+	if _, err := cpBuilder.Update(true); err != nil {
+		return nil, fmt.Errorf("update ClusterPolicy %s spec.gfd.enabled=true: %w", nvidiagpu.ClusterPolicyName, err)
+	}
+	glog.V(gpuparams.GpuLogLevel).Infof("Set ClusterPolicy %s spec.gfd.enabled to true", nvidiagpu.ClusterPolicyName)
+
+	product := baseGPUProductName(gpuProduct)
+	if product == "" {
+		var werr error
+		discovered, werr := waitForGPUProductLabel(apiClient, workerNodeSelector, nvidiagpu.LabelCheckInterval, nvidiagpu.ClusterPolicyReadyTimeout)
+		if werr != nil {
+			return nil, werr
+		}
+		product = baseGPUProductName(discovered)
+		glog.V(gpuparams.GpuLogLevel).Infof("Discovered %s=%q (stable key %q)", gpuProductLabelKey, discovered, product)
+	}
+	if product == "" {
+		return nil, fmt.Errorf("empty GPU product name after stripping %q suffix", gpuProductSharedSuffix)
+	}
+	glog.V(gpuparams.GpuLogLevel).Infof("Using stable device-plugin ConfigMap key %q", product)
+
+	out, err := updateTimeSlicingDevicePluginConfigMap(apiClient, product, replicas)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyDevicePluginConfigNodeLabels(apiClient, out.Data, workerNodeSelector); err != nil {
+		return nil, err
+	}
+
+	cpBuilder, err = nvidiagpu.Pull(apiClient, nvidiagpu.ClusterPolicyName)
+	if err != nil {
+		return nil, fmt.Errorf("pull ClusterPolicy %s before devicePlugin.config: %w", nvidiagpu.ClusterPolicyName, err)
+	}
+	if cpBuilder.Definition.Spec.DevicePlugin.Config == nil {
+		cpBuilder.Definition.Spec.DevicePlugin.Config = &nvidiagpuv1.DevicePluginConfig{}
+	}
+	cpBuilder.Definition.Spec.DevicePlugin.Config.Name = timeSlicingDevicePluginConfigMapName
+	cpBuilder.Definition.Spec.DevicePlugin.Config.Default = product
+	if _, err := cpBuilder.Update(true); err != nil {
+		return nil, fmt.Errorf("update ClusterPolicy %s devicePlugin.config: %w", nvidiagpu.ClusterPolicyName, err)
+	}
+	glog.V(gpuparams.GpuLogLevel).Infof("Set ClusterPolicy %s spec.devicePlugin.config.name=%q default=%q",
+		nvidiagpu.ClusterPolicyName, timeSlicingDevicePluginConfigMapName, product)
+
+	if err := applyDevicePluginConfigNodeLabels(apiClient, out.Data, workerNodeSelector); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func updateTimeSlicingDevicePluginConfigMap(apiClient *clients.Settings, gpuProduct string, replicas int) (*corev1.ConfigMap, error) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "updateTimeSlicingDevicePluginConfigMap"))
+	ns := nvidiagpu.NvidiaGPUNamespace
+	data := timeSlicingDevicePluginConfigData()
+	for k, v := range tsDPCD(gpuProduct, replicas) {
+		data[k] = v
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      timeSlicingDevicePluginConfigMapName,
+			Namespace: ns,
+		},
+		Data: data,
+	}
+	cms := apiClient.CoreV1Interface.ConfigMaps(ns)
+	created, err := cms.Create(context.TODO(), cm, metav1.CreateOptions{})
+	if err == nil {
+		glog.V(gpuparams.GpuLogLevel).Infof("Created ConfigMap %s/%s for device-plugin time-slicing", ns, timeSlicingDevicePluginConfigMapName)
+		return created, nil
+	}
+	if !k8serrors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("create ConfigMap %s/%s: %w", ns, timeSlicingDevicePluginConfigMapName, err)
+	}
+	existing, getErr := cms.Get(context.TODO(), timeSlicingDevicePluginConfigMapName, metav1.GetOptions{})
+	if getErr != nil {
+		return nil, fmt.Errorf("get existing ConfigMap %s/%s: %w", ns, timeSlicingDevicePluginConfigMapName, getErr)
+	}
+	if existing.Data == nil {
+		existing.Data = map[string]string{}
+	}
+	for k, v := range data {
+		existing.Data[k] = v
+	}
+	// Drop stale -SHARED keys when the base product entry is present.
+	for k := range existing.Data {
+		if !strings.HasSuffix(k, gpuProductSharedSuffix) {
+			continue
+		}
+		if _, ok := existing.Data[baseGPUProductName(k)]; ok {
+			delete(existing.Data, k)
+		}
+	}
+	updated, updErr := cms.Update(context.TODO(), existing, metav1.UpdateOptions{})
+	if updErr != nil {
+		return nil, fmt.Errorf("update ConfigMap %s/%s: %w", ns, timeSlicingDevicePluginConfigMapName, updErr)
+	}
+	glog.V(gpuparams.GpuLogLevel).Infof("Updated ConfigMap %s/%s for device-plugin time-slicing", ns, timeSlicingDevicePluginConfigMapName)
+	return updated, nil
+}
+
+func captureTimeSlicingConfigSnapshot(apiClient *clients.Settings) (*timeSlicingConfigSnapshot, error) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "captureTimeSlicingConfigSnapshot"))
+	snap := &timeSlicingConfigSnapshot{}
+
+	cpBuilder, err := nvidiagpu.Pull(apiClient, nvidiagpu.ClusterPolicyName)
+	if err != nil {
+		return nil, fmt.Errorf("pull ClusterPolicy %s: %w", nvidiagpu.ClusterPolicyName, err)
+	}
+	if cfg := cpBuilder.Definition.Spec.DevicePlugin.Config; cfg != nil &&
+		(cfg.Name != "" || cfg.Default != "") {
+		snap.hadDevicePluginConfig = true
+		cfgCopy := *cfg
+		snap.devicePluginConfig = &cfgCopy
+	}
+	if enabled := cpBuilder.Definition.Spec.GPUFeatureDiscovery.Enabled; enabled != nil {
+		v := *enabled
+		snap.gfdEnabled = &v
+	}
+
+	ns := nvidiagpu.NvidiaGPUNamespace
+	existing, getErr := apiClient.CoreV1Interface.ConfigMaps(ns).Get(
+		context.TODO(), timeSlicingDevicePluginConfigMapName, metav1.GetOptions{})
+	if getErr == nil {
+		snap.configMapExisted = true
+		snap.configMapData = copyStringMap(existing.Data)
+	} else if !k8serrors.IsNotFound(getErr) {
+		return nil, fmt.Errorf("get ConfigMap %s/%s: %w", ns, timeSlicingDevicePluginConfigMapName, getErr)
+	}
+	return snap, nil
+}
+
+func removeDevicePluginConfigNodeLabels(apiClient *clients.Settings, nodeSelector map[string]string) error {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "removeDevicePluginConfigNodeLabels"))
+	const devicePluginConfigLabel = "nvidia.com/device-plugin.config"
+
+	nodeBuilders, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: labels.Set(nodeSelector).String()})
+	if err != nil {
+		return fmt.Errorf("list nodes matching %v: %w", nodeSelector, err)
+	}
+	for _, nb := range nodeBuilders {
+		if nb.Definition.Labels == nil {
+			continue
+		}
+		value, ok := nb.Definition.Labels[devicePluginConfigLabel]
+		if !ok {
+			continue
+		}
+		nb = nb.RemoveLabel(devicePluginConfigLabel, value)
+		if _, err := nb.Update(); err != nil {
+			return fmt.Errorf("remove %s from node %s: %w", devicePluginConfigLabel, nb.Definition.Name, err)
+		}
+		glog.V(gpuparams.GpuLogLevel).Infof("Removed label %s from node %s", devicePluginConfigLabel, nb.Definition.Name)
+	}
+	return nil
+}
+
+func restoreTimeSlicingDevicePluginConfigMap(apiClient *clients.Settings, snap *timeSlicingConfigSnapshot) error {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "restoreTimeSlicingDevicePluginConfigMap"))
+	ns := nvidiagpu.NvidiaGPUNamespace
+	cms := apiClient.CoreV1Interface.ConfigMaps(ns)
+
+	if !snap.configMapExisted {
+		err := cms.Delete(context.TODO(), timeSlicingDevicePluginConfigMapName, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("delete ConfigMap %s/%s: %w", ns, timeSlicingDevicePluginConfigMapName, err)
+		}
+		glog.V(gpuparams.GpuLogLevel).Infof("Deleted ConfigMap %s/%s (created by time-slicing test)", ns, timeSlicingDevicePluginConfigMapName)
+		return nil
+	}
+
+	existing, getErr := cms.Get(context.TODO(), timeSlicingDevicePluginConfigMapName, metav1.GetOptions{})
+	if getErr != nil {
+		if k8serrors.IsNotFound(getErr) {
+			return nil
+		}
+		return fmt.Errorf("get ConfigMap %s/%s: %w", ns, timeSlicingDevicePluginConfigMapName, getErr)
+	}
+	existing.Data = copyStringMap(snap.configMapData)
+	if _, updErr := cms.Update(context.TODO(), existing, metav1.UpdateOptions{}); updErr != nil {
+		return fmt.Errorf("restore ConfigMap %s/%s: %w", ns, timeSlicingDevicePluginConfigMapName, updErr)
+	}
+	glog.V(gpuparams.GpuLogLevel).Infof("Restored ConfigMap %s/%s to pre-test state", ns, timeSlicingDevicePluginConfigMapName)
+	return nil
+}
+
+// removeTimeSlicingConfig reverses CreateTimeSlicingConfig: restores ClusterPolicy devicePlugin.config and GFD,
+// removes nvidia.com/device-plugin.config node labels, and restores or deletes the device-plugin ConfigMap.
+func removeTimeSlicingConfig(apiClient *clients.Settings, workerNodeSelector map[string]string, snap *timeSlicingConfigSnapshot, waitForReady bool) error {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "removeTimeSlicingConfig"))
+	if snap == nil {
+		return fmt.Errorf("time-slicing snapshot is nil")
+	}
+
+	if err := removeDevicePluginConfigNodeLabels(apiClient, workerNodeSelector); err != nil {
+		return err
+	}
+
+	cpBuilder, cpErr := nvidiagpu.Pull(apiClient, nvidiagpu.ClusterPolicyName)
+	if cpErr != nil {
+		glog.Warningf("ClusterPolicy %s not found, skipping devicePlugin.config restore: %v", nvidiagpu.ClusterPolicyName, cpErr)
+	} else {
+		if snap.hadDevicePluginConfig {
+			cpBuilder.Definition.Spec.DevicePlugin.Config = snap.devicePluginConfig
+		} else {
+			cpBuilder.Definition.Spec.DevicePlugin.Config = nil
+		}
+		cpBuilder.Definition.Spec.GPUFeatureDiscovery.Enabled = snap.gfdEnabled
+		if _, err := cpBuilder.Update(false); err != nil {
+			return fmt.Errorf("restore ClusterPolicy %s devicePlugin.config and GFD: %w", nvidiagpu.ClusterPolicyName, err)
+		}
+		glog.V(gpuparams.GpuLogLevel).Infof("Restored ClusterPolicy %s devicePlugin.config and GFD to pre-test state", nvidiagpu.ClusterPolicyName)
+	}
+
+	if err := restoreTimeSlicingDevicePluginConfigMap(apiClient, snap); err != nil {
+		return err
+	}
+
+	if err := restartGPUOperatorDevicePluginDaemonsets(apiClient); err != nil {
+		return err
+	}
+
+	if cpErr != nil {
+		glog.V(gpuparams.GpuLogLevel).Infof("Skipping ClusterPolicy wait after time-slicing cleanup (ClusterPolicy missing)")
+		return nil
+	}
+
+	if !waitForReady {
+		glog.V(gpuparams.GpuLogLevel).Infof("Skipping ClusterPolicy wait after time-slicing cleanup (test may have failed)")
+		return nil
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Waiting for ClusterPolicy to be ready after time-slicing cleanup")
+	if err := wait.ClusterPolicyReady(apiClient, nvidiagpu.ClusterPolicyName,
+		nvidiagpu.ClusterPolicyReadyCheckInterval, nvidiagpu.ClusterPolicyReadyTimeout); err != nil {
+		return fmt.Errorf("wait for ClusterPolicy ready after time-slicing cleanup: %w", err)
+	}
+	return nil
+}
+
+func restartGPUOperatorDevicePluginDaemonsets(apiClient *clients.Settings) error {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "restartGPUOperatorDevicePluginDaemonsets"))
+	ns := nvidiagpu.NvidiaGPUNamespace
+	names := []string{"nvidia-device-plugin-daemonset", "gpu-feature-discovery"}
+	patch := []byte(fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`,
+		time.Now().Format(time.RFC3339),
+	))
+	for _, name := range names {
+		_, err := apiClient.DaemonSets(ns).Patch(
+			context.TODO(), name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				glog.V(gpuparams.GpuLogLevel).Infof("DaemonSet %s/%s not found, skipping rollout restart", ns, name)
+				continue
+			}
+			return fmt.Errorf("rollout restart DaemonSet %s/%s: %w", ns, name, err)
+		}
+		glog.V(gpuparams.GpuLogLevel).Infof("Triggered rollout restart of DaemonSet %s/%s", ns, name)
+	}
+	return nil
 }
 
 // SelectMigProfile queries MIG profiles from hardware and selects/validates the MIG index.
@@ -701,7 +1393,6 @@ func SelectMigProfile(workerNodeSelector map[string]string, useMigIndex int, mig
 // It returns an error if the label is not found or does not have the expected value.
 func CheckMigConfigState(workerNodeSelector map[string]string) error {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Check for MIG config state on GPU nodes"))
-	migConfigStateLabel := "nvidia.com/mig.config.state"
 	expectedLabelValue := "success"
 	err := wait.NodeLabelExists(inittools.APIClient, migConfigStateLabel, expectedLabelValue,
 		labels.Set(workerNodeSelector), nvidiagpu.LabelCheckInterval, nvidiagpu.LabelCheckTimeout)
@@ -801,13 +1492,42 @@ func SetMIGLabelsOnNodes(migCapabilities []MIGProfileInfo, useMigIndex int, work
 		glog.V(gpuparams.GpuLogLevel).Infof("Successfully set MIG %s strategy label on node '%s'", migStrategy, nodeBuilder.Definition.Name)
 
 		glog.V(gpuparams.GpuLogLevel).Infof("Setting MIG configuration label %s on node '%s' (overwrite=true)", MigProfile, nodeBuilder.Definition.Name)
-		nodeBuilder = nodeBuilder.WithLabel("nvidia.com/mig.config", MigProfile)
+		nodeBuilder = nodeBuilder.WithLabel(migConfigLabel, MigProfile)
 		_, err = nodeBuilder.Update()
 		Expect(err).ToNot(HaveOccurred(), "Error updating node '%s' with MIG label: %v", nodeBuilder.Definition.Name, err)
 		glog.V(gpuparams.GpuLogLevel).Infof("Successfully set MIG configuration label on node '%s' with %s", nodeBuilder.Definition.Name, MigProfile)
 	}
 
 	return useMigProfile
+}
+
+// IsMig reports whether any GPU worker node has active or failed MIG configuration.
+// It returns true when nvidia.com/mig.config.state is "failed", or when nvidia.com/mig.config
+// is set to a value other than "all-disabled".
+func IsMig(workerNodeSelector map[string]string) (bool, error) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "IsMig test"))
+	nodeBuilders, err := nodes.List(inittools.APIClient, metav1.ListOptions{LabelSelector: labels.Set(workerNodeSelector).String()})
+	if err != nil {
+		return false, fmt.Errorf("list nodes for MIG check: %w", err)
+	}
+	for _, nodeBuilder := range nodeBuilders {
+		nodeLabels := nodeBuilder.Object.Labels
+		if nodeLabels[migConfigStateLabel] == "failed" {
+			glog.V(gpuparams.GpuLogLevel).Infof("Node '%s' has MIG config state 'failed'", nodeBuilder.Object.Name)
+			return true, nil
+		}
+		if cfg, ok := nodeLabels[migConfigLabel]; ok && cfg != migConfigDisabled {
+			glog.V(gpuparams.GpuLogLevel).Infof("Node '%s' has MIG config '%s' (not %s)", nodeBuilder.Object.Name, cfg, migConfigDisabled)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// DisableMig resets MIG labels to all-disabled on GPU worker nodes and waits for ClusterPolicy to be ready.
+func DisableMig(workerNodeSelector map[string]string) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Disable MIG on GPU nodes"))
+	ResetMIGLabelsToDisabled(workerNodeSelector, true)
 }
 
 // ResetMIGLabelsToDisabled sets MIG strategy and configuration labels to "all-disabled" on GPU worker nodes.
@@ -817,8 +1537,8 @@ func ResetMIGLabelsToDisabled(workerNodeSelector map[string]string, waitForReady
 	nodeBuilders, err := nodes.List(inittools.APIClient, metav1.ListOptions{LabelSelector: labels.Set(workerNodeSelector).String()})
 	Expect(err).ToNot(HaveOccurred(), "Error listing worker nodes: %v", err)
 	for _, nodeBuilder := range nodeBuilders {
-		glog.V(gpuparams.Gpu10LogLevel).Infof("Setting MIG configuration label to 'all-disabled' on node '%s' (overwrite=true)", nodeBuilder.Definition.Name)
-		nodeBuilder = nodeBuilder.WithLabel("nvidia.com/mig.config", "all-disabled")
+		glog.V(gpuparams.Gpu10LogLevel).Infof("Setting MIG configuration label to '%s' on node '%s' (overwrite=true)", migConfigDisabled, nodeBuilder.Definition.Name)
+		nodeBuilder = nodeBuilder.WithLabel(migConfigLabel, migConfigDisabled)
 		_, err = nodeBuilder.Update()
 		Expect(err).ToNot(HaveOccurred(), "Error updating node '%s' with MIG label: %v", nodeBuilder.Definition.Name, err)
 		glog.V(gpuparams.Gpu10LogLevel).Infof("Successfully set MIG configuration label on node '%s'", nodeBuilder.Definition.Name)
@@ -930,6 +1650,28 @@ func DeployGPUWorkload(
 	return gpuMigPodPulled
 }
 
+// DeployTimeslicingGPUBurnPods creates TsPodCount GPU burn pods for time-slicing.
+// Pod k (1-based) is named gpu-burn-pod-{k}-slice-{n} where n is TsInstances[k-1],
+// each requesting n units of nvidia.com/gpu (device-plugin time-slicing replicas).
+// ReadTimeSlicingParameters must have run so TsPodCount and TsInstances are populated.
+func DeployTimeslicingGPUBurnPods(imageName, namespace, podLabel string) []*pod.Builder {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "DeployTimeslicingGPUBurnPods"))
+	Expect(TsPodCount).To(BeNumerically(">", 0), "TsPodCount must be set for time-slicing pods")
+	Expect(len(TsInstances)).To(BeNumerically(">=", TsPodCount),
+		"TsInstances must have at least TsPodCount entries (got %d, need %d)", len(TsInstances), TsPodCount)
+
+	pods := make([]*pod.Builder, 0, TsPodCount)
+	for i := 0; i < TsPodCount; i++ {
+		slices := TsInstances[i]
+		podName := fmt.Sprintf("gpu-burn-pod-%d-slice-%d", i+1, slices)
+		glog.V(gpuparams.Gpu10LogLevel).Infof("Creating time-slicing gpu-burn pod %s requesting nvidia.com/gpu=%d",
+			podName, slices)
+		pb := DeployGPUWorkload(imageName, podName, namespace, "time-slicing", slices, podLabel)
+		pods = append(pods, pb)
+	}
+	return pods
+}
+
 // waitForGPUBurnPodToComplete waits for the GPU burn pod to reach Running phase,
 // then waits for it to complete and reach Succeeded phase.
 func waitForGPUBurnPodToComplete(gpuMigPodPulled *pod.Builder, namespace string) {
@@ -949,6 +1691,7 @@ func waitForGPUBurnPodToComplete(gpuMigPodPulled *pod.Builder, namespace string)
 // logPodEvents logs events related to a specific pod in the given namespace.
 // This is used to give more info about the pod when it exists, but it is in unexpected state.
 func logPodEvents(podName, namespace string) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "logPodEvents"))
 	events, err := inittools.APIClient.Events(namespace).List(context.TODO(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod", podName),
 	})
@@ -975,22 +1718,33 @@ func logPodEvents(podName, namespace string) {
 // isRunning checks and waits for the GPU burn pod to reach the Running phase.
 // It first checks it quickly and if necessary, it waits for it to reach the Running phase.
 // Log validation ensures that the logs are from the pod that was created at the start of the test.
-func isRunning(gpuPod *pod.Builder, namespace string) {
+// Return values:
+// 0: Succeeeded
+// 1: Running
+// 2: Pending
+// 3: any other
+func isRunning(gpuPod *pod.Builder, namespace string) int {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "isRunning"))
 	// This is to avoid waiting, if the pod is already in Running or Succeeded phase.
 	// If pod was Completed (or Running) already, there's no need to wait.
 	// Avoiding the timeout in case it is Completed already is preferred.
 	_, err := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
 	Expect(err).ToNot(HaveOccurred(), "Pod %s does not exist in namespace %s with error: %v", gpuPod.Definition.Name, namespace, err)
-	if gpuPod.Object.Status.Phase == corev1.PodRunning || gpuPod.Object.Status.Phase == corev1.PodSucceeded {
-		return
+	switch gpuPod.Object.Status.Phase {
+	case corev1.PodSucceeded:
+		return 0
+	case corev1.PodRunning:
+		return 1
 	}
+
 	// Waiting for the pod to reach Running phase, if it was not already.
 	// If the pod is left in Pending state, timeout will occur.
 	err = gpuPod.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
 	var err2 error
 	var pod2 *pod.Builder
 	if err != nil {
-		// pod exists, but is not running
+		// pod exists, but is not running — distinguish Failed from Pending/other.
+		isFailed(gpuPod, namespace)
 		// Using pod2 to avoid confusion with previous pod pull
 		pod2, err2 = pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
 		Expect(err2).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
@@ -998,14 +1752,40 @@ func isRunning(gpuPod *pod.Builder, namespace string) {
 		glog.V(gpuparams.Gpu10LogLevel).Infof("Pod %s is likely Pending for some reason: %s (%s). Error: %v, Error2: %v",
 			pod2.Definition.Name, pod2.Object.Status.Phase, pod2.Object.Status.Reason, err, err2)
 		logPodEvents(pod2.Definition.Name, namespace)
+		return 2
+	} else {
+		return 3
 	}
 }
 
+// isFailed checks whether the GPU burn pod is in Failed phase.
+// It pulls the latest pod state; when Failed, logs pod events and fails the test (same style as isCompleted on timeout).
+func isFailed(gpuPod *pod.Builder, namespace string) bool {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "isFailed"))
+	pulled, err := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
+	Expect(err).ToNot(HaveOccurred(), "Pod %s does not exist in namespace %s with error: %v",
+		gpuPod.Definition.Name, namespace, err)
+	if pulled.Object.Status.Phase != corev1.PodFailed {
+		return false
+	}
+
+	logPodEvents(pulled.Definition.Name, namespace)
+	return true
+	// Expect(pulled.Object.Status.Phase).To(Equal(corev1.PodSucceeded),
+	// 	"gpu-burn pod %s/%s is Failed; status=%+v", namespace, pulled.Definition.Name, pulled.Object.Status)
+}
+
 // isCompleted checks if the GPU burn pod reaches the Completed phase.
-func isCompleted(gpuMigPodPulled *pod.Builder, namespace string) {
+func isCompleted(gpuMigPodPulled *pod.Builder, namespace string) bool {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "isCompleted"))
 	err := gpuMigPodPulled.WaitUntilInStatus(corev1.PodSucceeded, nvidiagpu.BurnPodSuccessTimeout)
-	Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
-		"namespace '%s' to go to Completed phase: %v", namespace, err)
+	if err != nil {
+		ret := isFailed(gpuMigPodPulled, namespace)
+		Expect(ret).To(BeFalse(), "gpu-burn pod %s/%s is not Failed; status=%+v", namespace, gpuMigPodPulled.Definition.Name, gpuMigPodPulled.Object.Status)
+		Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
+			"namespace '%s' to go to Completed phase: %v", namespace, err)
+	}
+	return true
 }
 
 // GetGPUBurnPodLogs retrieves the logs from the GPU burn pod with MIG configuration.
@@ -1050,20 +1830,82 @@ func CheckGPUBurnPodLogs(gpuBurnMigLogs string, migInstanceCount int) {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("Gpu-burn pod execution with MIG configuration was successful")
 }
 
-// MIGCapabilities queries GPU hardware directly using nvidia-smi
-// to discover MIG capabilities. This is a fallback when GFD labels are not available.
-// Returns true if MIG is supported, along with available MIG instance profiles.
-func MIGProfiles(apiClient *clients.Settings, nodeSelector map[string]string) (bool, []MIGProfileInfo, error) {
+// CheckTimeSlicingGPUBurnPodLogs validates gpu-burn output for a completed time-slicing pod (one visible GPU per pod).
+func CheckTimeSlicingGPUBurnPodLogs(logs string) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "CheckTimeSlicingGPUBurnPodLogs"))
+	Expect(strings.Contains(logs, "Tested 1 GPUs")).To(BeTrue(),
+		"gpu-burn logs should contain 'Tested 1 GPUs'; logs excerpt: %.500s", logs)
+	CheckGPUBurnPodLogs(logs, 1)
+}
+
+// MonitorTimeslicingGPULoad polls one time-slicing gpu-burn pod has succeeded
+// nvidia-smi checks (pmon and query-compute-apps) and logs their output.
+func MonitorTimeslicingGPULoad(burn *nvidiagpu.GPUBurnConfig, podInfo TsPodInfo,
+	workerNodeSelector map[string]string) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s %v", colorLog(colorCyan+colorBold, "Monitor GPU load with nvidia-smi pmon and dmon, running pod:"), podInfo.PodName)
+	pollInterval := 30 * time.Second
+
+	pmonCmd := []string{"nvidia-smi", "pmon", "-d", "1", "-c", "1"}
+	csvCmd := []string{"nvidia-smi", "--query-compute-apps=pid,process_name,used_memory,timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid", "--format=csv,nounits"}
+
+	activePendingOrRunning := false
+	pulled, err := pod.Pull(inittools.APIClient, podInfo.PodName, podInfo.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "error pulling gpu-burn pod %s in %s: %v",
+		podInfo.PodName, podInfo.Namespace, err)
+	name := podInfo.PodName
+	phase := pulled.Object.Status.Phase
+	glog.V(gpuparams.Gpu100LogLevel).Infof("Pod: %s at phase: %s", name, phase)
+
+	isFailed(pulled, podInfo.Namespace)
+
+	switch phase {
+	case corev1.PodPending, corev1.PodRunning:
+		activePendingOrRunning = true
+	case corev1.PodSucceeded:
+		By(fmt.Sprintf("Completed pod %s", name))
+	default:
+		// PodUnknown, etc. — treat as still in progress
+		activePendingOrRunning = true
+	}
+
+	if activePendingOrRunning {
+		labelPods, errList := pod.List(inittools.APIClient, burn.Namespace, metav1.ListOptions{LabelSelector: burn.PodLabel})
+		if errList != nil {
+			glog.V(gpuparams.Gpu10LogLevel).Infof("listing pods with %s: %v", burn.PodLabel, errList)
+		} else {
+			glog.V(gpuparams.GpuLogLevel).Infof("time-slicing monitor: %d pod(s) with label %s in namespace %s",
+				len(labelPods), burn.PodLabel, burn.Namespace)
+		}
+
+		outPmon := GetCmdOutput(inittools.APIClient, workerNodeSelector, pmonCmd)
+		status, pids := GetPidsFromPmon(outPmon, 2)
+		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v with status: %v", pids, status)
+		glog.V(gpuparams.GpuLogLevel).Infof("\ntime-slicing monitor: nvidia-smi pmon:\n%s\n",
+			outPmon)
+
+		outCSV := GetCmdOutput(inittools.APIClient, workerNodeSelector, csvCmd)
+		status, pids = GetPidFromCSV(outCSV, 1)
+		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v with status: %v", pids, status)
+		glog.V(gpuparams.GpuLogLevel).Infof("\ntime-slicing monitor: nvidia-smi CSV:\n%s\n",
+			outCSV)
+
+		status, podInfo := GetPodsWithPids(inittools.APIClient, workerNodeSelector, pids)
+		Expect(status).To(BeTrue(), "Error getting pod info: %v", err)
+		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod info: %v", podInfo)
+	}
+	time.Sleep(pollInterval)
+}
+
+// findDriverPodOnNode returns the nvidia-driver pod on the first node matching nodeSelector.
+func findDriverPodOnNode(apiClient *clients.Settings, nodeSelector map[string]string) (podName, namespace string) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "findDriverPodOnNode"))
 	nodeBuilder, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: labels.Set(nodeSelector).String()})
 	Expect(err).ToNot(HaveOccurred(), "Error listing nodes: %v", err)
 	Expect(len(nodeBuilder)).ToNot(BeZero(), "no nodes found matching selector")
 
-	// Get the first GPU node
-	firstNode := nodeBuilder[0]
-	nodeName := firstNode.Object.Name
+	nodeName := nodeBuilder[0].Object.Name
 
-	// Find a driver pod on this node to query hardware
-	driverPods, err := apiClient.Pods("nvidia-gpu-operator").List(context.TODO(), metav1.ListOptions{
+	driverPods, err := apiClient.Pods(nvidiagpu.NvidiaGPUNamespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/component=nvidia-driver",
 		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
 	})
@@ -1071,8 +1913,15 @@ func MIGProfiles(apiClient *clients.Settings, nodeSelector map[string]string) (b
 	Expect(len(driverPods.Items)).ToNot(BeZero(), "No driver pods found on node %s", nodeName)
 
 	driverPod := driverPods.Items[0]
-	podName := driverPod.Name
-	namespace := driverPod.Namespace
+	return driverPod.Name, driverPod.Namespace
+}
+
+// MIGCapabilities queries GPU hardware directly using nvidia-smi
+// to discover MIG capabilities. This is a fallback when GFD labels are not available.
+// Returns true if MIG is supported, along with available MIG instance profiles.
+func MIGProfiles(apiClient *clients.Settings, nodeSelector map[string]string) (bool, []MIGProfileInfo, error) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "MIGProfiles"))
+	podName, namespace := findDriverPodOnNode(apiClient, nodeSelector)
 
 	// Query MIG capabilities using nvidia-smi
 	// First, try to get MIG instance profiles directly (works even if MIG mode is not enabled)
@@ -1095,6 +1944,7 @@ func MIGProfiles(apiClient *clients.Settings, nodeSelector map[string]string) (b
 // ParseCLIParameters parses CLI parameters and sets the global variables.
 // This must be called after flags are parsed (e.g., in a BeforeSuite or BeforeAll hook).
 func ParseCLIParameters() {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "ParseCLIParameters"))
 	wasProvided := isFlagProvided("mixed.mig.instances")
 	if wasProvided {
 		MixedMigInstances = parseMigInstances(MigInstances, strconv.Itoa(defaultMigInstances))
@@ -1106,6 +1956,7 @@ func ParseCLIParameters() {
 // isFlagProvided checks if a flag was explicitly set on the command line.
 // Returns true if the flag was provided, false if it's using the default value.
 func isFlagProvided(flagName string) bool {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s %v", colorLog(colorCyan+colorBold, "isFlagProvided:"), flagName)
 	provided := false
 	flag.Visit(func(f *flag.Flag) {
 		if f.Name == flagName {
@@ -1116,6 +1967,7 @@ func isFlagProvided(flagName string) bool {
 }
 
 func parseMigInstances(s string, defaults string) []int {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "parseMigInstances"))
 	regex := regexp.MustCompile(`\d+`)
 	matches := regex.FindAllString(s, -1)
 	if len(matches) == 0 {
@@ -1132,6 +1984,7 @@ func parseMigInstances(s string, defaults string) []int {
 
 func LogCLIParameterValues() {
 	// Check if the flags were explicitly provided on the command line
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "LogCLIParameterValues"))
 	wasProvided := isFlagProvided("single.mig.profile")
 	if !wasProvided {
 		GinkgoWriter.Printf("Flag --single.mig.profile not provided, using default: %d\n", SingleMigProfile)
@@ -1161,12 +2014,37 @@ func LogCLIParameterValues() {
 	} else {
 		glog.V(gpuparams.Gpu10LogLevel).Infof("%s %v", colorLog(colorCyan+colorBold, "Value of --no-color parameter: "), NoColor)
 	}
+
+	// wasProvided = isFlagProvided("time.slicing.pod-count")
+	// if !wasProvided {
+	// 	GinkgoWriter.Printf("Flag --time.slicing.pod-count not provided, using default: %d\n", TsPodCount)
+	// } else {
+	// 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s %d", colorLog(colorCyan+colorBold, "Value of --time.slicing.pod-count parameter: "), TsPodCount)
+	// }
+
+	wasProvided = isFlagProvided("time.slicing.instances")
+	if !wasProvided {
+		GinkgoWriter.Printf("Flag --time.slicing.instances not provided, using default: %q\n", defaultTsInstancesCSV)
+	} else {
+		glog.V(gpuparams.Gpu10LogLevel).Infof("%s %q, parsed: %v\n",
+			colorLog(colorCyan+colorBold, "Value of --time.slicing.instances parameter: "), TsInstancesCSV,
+			parseMigInstances(TsInstancesCSV, defaultTsInstancesCSV))
+	}
+
+	wasProvided = isFlagProvided("time.slicing.mon-after-pod")
+	if !wasProvided {
+		GinkgoWriter.Printf("Flag --time.slicing.mon-after-pod not provided, using default: %d\n", TsMonAfterPod)
+	} else {
+		glog.V(gpuparams.Gpu10LogLevel).Infof("%s %d", colorLog(colorCyan+colorBold, "Value of --time.slicing.mon-after-pod parameter: "), TsMonAfterPod)
+	}
+
 }
 
 // ExecCmdInPod executes a command (e.g. nvidia-smi mig -lgip) in a pod and returns the output
 // If similar function is needed for other purposes, consider renaming
 func ExecCmdInPod(apiClient *clients.Settings, podName, namespace string, command []string, timeout time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "ExecCmdInPod"))
 	defer cancel()
 
 	// Pull the pod using the pod builder
@@ -1218,6 +2096,8 @@ func ExecCmdInPod(apiClient *clients.Settings, podName, namespace string, comman
 // parseMIGProfiles parses MIG profile names from nvidia-smi mig -lgip output
 // Handles formats like "MIG 1g.5gb", "MIG 1g.5gb+me", "1g.5gb", etc.
 func parseMIGProfiles(output string) []MIGProfileInfo {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "parseMIGProfiles"))
+
 	var profiles []MIGProfileInfo
 	// Regex to match MIG profile patterns from first line, e.g.:
 	// |   0  MIG 1g.5gb          19     7/7        4.75       No     14     0     0   |
@@ -1302,4 +2182,141 @@ func parseMIGProfiles(output string) []MIGProfileInfo {
 	}
 	Expect(len(profiles)).ToNot(BeZero(), "no profiles found")
 	return profiles
+}
+
+func GetCmdOutput(apiClient *clients.Settings, nodeSelector map[string]string, cmd []string) string {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "GetCmdOutput"))
+	podName, namespace := findDriverPodOnNode(apiClient, nodeSelector)
+
+	// send command to driver pod (usually nvidia-smi)
+	// e.g. cmd := []string{"nvidia-smi", "pmon", "-c", "1"}
+	var cmd1 string
+	for _, cmd := range cmd {
+		cmd1 = cmd1 + cmd + " "
+	}
+	glog.V(gpuparams.Gpu10LogLevel).Infof("oc rsh -n %s pod/%s %v", namespace, podName, cmd1)
+	output, err := ExecCmdInPod(apiClient, podName, namespace, cmd, 30*time.Second)
+	Expect(err).ToNot(HaveOccurred(), "Error getting command output: %v", err)
+	glog.V(gpuparams.Gpu100LogLevel).Infof("Command output: \n%s", output)
+
+	return output
+}
+
+func CheckGPUBurnPids(apiClient *clients.Settings, nodeSelector map[string]string, cmd []string) string {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "CheckGPUBurnPids"))
+	podName, namespace := findDriverPodOnNode(apiClient, nodeSelector)
+
+	// send command to driver pod (usually nvidia-smi)
+	// e.g. cmd := []string{"nvidia-smi", "pmon", "-c", "1"}
+	var cmd1 string
+	for _, cmd := range cmd {
+		cmd1 = cmd1 + cmd + " "
+	}
+	glog.V(gpuparams.Gpu10LogLevel).Infof("oc rsh -n %s pod/%s %v", namespace, podName, cmd1)
+	output, err := ExecCmdInPod(apiClient, podName, namespace, cmd, 30*time.Second)
+	Expect(err).ToNot(HaveOccurred(), "Error getting MIG profiles: %v", err)
+	glog.V(gpuparams.Gpu100LogLevel).Infof("Available MIG instance profiles: \n%s", output)
+
+	return output
+}
+
+// CSVLineRe matches one data line from "nvidia-smi --<cmd> --format=csv,nounits" at the time.
+// FindAllStringSubmatch returns one element per line: matches[0] = [fullMatch, cap1, cap2, ...].
+// So capture groups are matches[0][1]=pid, matches[0][2]=process_name, matches[0][3]=used_memory, ..., matches[0][8]=gpu_uuid.
+var CSVLineRe = regexp.MustCompile(`^(\d+),.(.+?),.(\d+),.(.+?),.(.+?),.(.+?),.(.+?),.(.+?)$`)
+
+// pmonLineRe matches one data line from "nvidia-smi pmon -c 1".
+// With -c values bigger than 1, duplicate PIDs can appear in the output.
+// FindAllStringSubmatch returns one element per line: matches[0] = [fullMatch, cap1, cap2, ...].
+// So capture groups are matches[0][1]=gpuIdx, matches[0][2]=pid, matches[0][3]=type, ..., matches[0][10]=command.
+var pmonLineRe = regexp.MustCompile(`^\s*(\d+)\s+(\d+|-)\s+([CG]|-)\s+(\d+|-)\s+(\d+|-)\s+(\d+|-)\s+(\d+|-)\s+(\d+|-)\s+(\d+|-)\s+(\S+)\s*$`)
+
+// PidParseConfig configures how to extract PIDs from regex-matched lines (e.g. nvidia-smi CSV or pmon output).
+type PidParseConfig struct {
+	Re         *regexp.Regexp // line regex; capture groups form row[1], row[2], ...
+	PidColumn  int            // index into row for the PID value (row[PidColumn])
+	SkipColumn int            // if >= 0, skip line when row[SkipColumn] == "-"
+}
+
+// GetPidsWithRegex parses output line-by-line, matches each line with re, and collects integer values from the configured column.
+func GetPidsWithRegex(output string, cfg PidParseConfig) (bool, []int) {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "GetPidsWithRegex"))
+	pids := []int{}
+	glog.V(gpuparams.GpuLogLevel).Infof("regex: %v", cfg)
+	glog.V(gpuparams.GpuLogLevel).Infof("output: %q", output)
+	for _, line := range strings.Split(output, "\n") {
+		glog.V(gpuparams.GpuLogLevel).Infof("line: %q", line)
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		matches := cfg.Re.FindAllStringSubmatch(line, -1)
+		if len(matches) == 0 {
+			glog.V(gpuparams.GpuLogLevel).Infof("line did not match: %q", line)
+			continue
+		}
+		row := matches[0]
+		if cfg.SkipColumn >= 0 && cfg.SkipColumn < len(row) && row[cfg.SkipColumn] == "-" {
+			continue
+		}
+		if cfg.PidColumn >= len(row) {
+			continue
+		}
+		pid, err := strconv.Atoi(row[cfg.PidColumn])
+		if err != nil {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+
+	pids = uniqueInts(pids)
+	return true, pids
+}
+
+func uniqueInts(s []int) []int {
+	seen := make(map[int]struct{})
+	out := make([]int, 0, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func GetPidFromCSV(output string, index int) (bool, []int) {
+	return GetPidsWithRegex(output, PidParseConfig{
+		Re:         CSVLineRe,
+		PidColumn:  index,
+		SkipColumn: 2,
+	})
+}
+
+func GetPidsFromPmon(output string, index int) (bool, []int) {
+	return GetPidsWithRegex(output, PidParseConfig{
+		Re:         pmonLineRe,
+		PidColumn:  index,
+		SkipColumn: 2,
+	})
+}
+
+// pid vs pod
+type PodInfo struct {
+	PodName string
+	pid     int
+}
+
+func GetPodsWithPids(apiClient *clients.Settings, nodeSelector map[string]string, pids []int) (bool, []PodInfo) {
+	glog.V(gpuparams.Gpu100LogLevel).Infof("GetPodsWithPids")
+	// var podInfo []PodInfo
+	// return true, []PodInfo(PodInfo{PodName: "pod1", pid: 1})
+	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v", pids)
+	for _, pid := range pids {
+		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pid: %d", pid)
+		podName := fmt.Sprintf("pod-%d", pid)
+		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod name: %s", podName)
+	}
+	return true, []PodInfo{}
 }

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -2303,7 +2303,6 @@ func GetPidsFromPmon(output string, index int) (bool, []int) {
 	})
 }
 
-
 func GetPodsWithPids(apiClient *clients.Settings, nodeSelector map[string]string, pids []int) {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "GetPidsWithRegex"))
 	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v", pids)

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -784,6 +784,26 @@ func IsLabelInFilter(label string) bool {
 	return labelInFilter
 }
 
+// AnyLabelInFilter checks if any of the given labels is present in the Ginkgo label filter.
+func AnyLabelInFilter(labels ...string) bool {
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "AnyLabelInFilter"))
+	filterQuery := GinkgoLabelFilter()
+	glog.V(gpuparams.Gpu100LogLevel).Infof("Checking if any of labels %v is present in Ginkgo label filter: %s", labels, filterQuery)
+
+	if filterQuery == "" {
+		return false
+	}
+
+	for _, label := range labels {
+		if strings.Contains(filterQuery, label) {
+			glog.V(gpuparams.GpuLogLevel).Infof("Label '%s' is present in Ginkgo label filter", label)
+			return true
+		}
+	}
+
+	return false
+}
+
 // ShouldKeepOperator checks if the operator should be kept based on test labels and upgrade channel
 func ShouldKeepOperator(labelsToCheck []string) bool {
 	glog.V(gpuparams.Gpu100LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "ShouldKeepOperator"))

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	// "os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -37,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	// "sigs.k8s.io/yaml"
 )
 
 // TestSingleMIGGPUBurn performs the GPU Burn test with single strategy MIG Configuration
@@ -623,7 +621,7 @@ func TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig *nvidiagpuconfig.NvidiaGPUCo
 					continue
 				}
 				ret1 := isRunning(podInfo.Pod, podInfo.Namespace)
-				if ret1 > 1 { // monitor once, and wait until pod is completed
+				if ret1 >= 1 { // monitor once, and wait until pod is completed
 					// skip if the pod was already succeeded
 					MonitorTimeslicingGPULoad(burn, podInfo, workerNodeSelector)
 					// pmonOut := GetCmdOutput(inittools.APIClient, workerNodeSelector, []string{"nvidia-smi", "pmon", "-d", "1", "-c", "1"})
@@ -2203,24 +2201,6 @@ func GetCmdOutput(apiClient *clients.Settings, nodeSelector map[string]string, c
 	return output
 }
 
-func CheckGPUBurnPids(apiClient *clients.Settings, nodeSelector map[string]string, cmd []string) string {
-	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "CheckGPUBurnPids"))
-	podName, namespace := findDriverPodOnNode(apiClient, nodeSelector)
-
-	// send command to driver pod (usually nvidia-smi)
-	// e.g. cmd := []string{"nvidia-smi", "pmon", "-c", "1"}
-	var cmd1 string
-	for _, cmd := range cmd {
-		cmd1 = cmd1 + cmd + " "
-	}
-	glog.V(gpuparams.Gpu10LogLevel).Infof("oc rsh -n %s pod/%s %v", namespace, podName, cmd1)
-	output, err := ExecCmdInPod(apiClient, podName, namespace, cmd, 30*time.Second)
-	Expect(err).ToNot(HaveOccurred(), "Error getting MIG profiles: %v", err)
-	glog.V(gpuparams.Gpu100LogLevel).Infof("Available MIG instance profiles: \n%s", output)
-
-	return output
-}
-
 // CSVLineRe matches one data line from "nvidia-smi --<cmd> --format=csv,nounits" at the time.
 // FindAllStringSubmatch returns one element per line: matches[0] = [fullMatch, cap1, cap2, ...].
 // So capture groups are matches[0][1]=pid, matches[0][2]=process_name, matches[0][3]=used_memory, ..., matches[0][8]=gpu_uuid.
@@ -2304,7 +2284,7 @@ func GetPidsFromPmon(output string, index int) (bool, []int) {
 }
 
 func GetPodsWithPids(apiClient *clients.Settings, nodeSelector map[string]string, pids []int) {
-	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "GetPidsWithRegex"))
+	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "GetPodsWithPids"))
 	glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pids: %v", pids)
 	for _, pid := range pids {
 		glog.V(gpuparams.GpuLogLevel).Infof("Time-slicing pod pid: %d", pid)

--- a/pkg/mig/migtypes.go
+++ b/pkg/mig/migtypes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	nvidiagpuv1 "github.com/NVIDIA/gpu-operator/api/nvidia/v1"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/pod"
 )
 
@@ -37,6 +38,22 @@ type MigPodInfo struct {
 	MigProfileInfo MIGProfileInfo // MIG profile information
 }
 
+type TsPodInfo struct {
+	PodName   string       // name of the pod
+	Namespace string       // namespace of the pod
+	Pod       *pod.Builder // pod object
+	Checked   bool         // whether the pod has been checked
+}
+
+// PMonRow is one data row from "nvidia-smi pmon -c 1" output.
+// Pid is 0 when the GPU slot has no process (pid column is "-").
+type PMonRow struct {
+	GpuIdx  int    // GPU index (0-based)
+	Pid     int    // Process ID; 0 if no process
+	Type    string // C/G or -
+	Command string // Process name, e.g. gpu_burn
+}
+
 // ANSI color constants for console output highlighting
 // colors are \033[31m - red through \033[37m - white
 const (
@@ -64,6 +81,10 @@ var (
 	MigInstances      string
 	NoColor           bool
 	MixedMigInstances []int
+	TsPodCount        int
+	TsInstancesCSV    string
+	TsInstances       []int // first TsPodCount entries after validation; slices per pod
+	TsMonAfterPod     int   // minimum number of pods running before monitoring starts
 )
 
 const (
@@ -72,8 +93,14 @@ const (
 )
 
 const (
-	MIGStrategySingle = "single"
-	MIGStrategyMixed  = "mixed"
+	MIGStrategySingle     = "single"
+	MIGStrategyMixed      = "mixed"
+	MaxTsSlices       int = 8 // max time-slice replicas per GPU (device plugin)
+	// MaxTsInstance is the maximum sum of per-pod time-slice counts for one GPU.
+	MaxTsInstance int = 100
+	// defaultTsInstancesCSV has MaxTsSlices entries; the first TsPodCount values are used.
+	defaultTsInstancesCSV = "8" // e.g. "8,1,3,2,6,5,8,8"
+	//defaultTsMonAfterPod   int = 1 // start monitoring pods after 1 pod is running
 )
 
 func init() {
@@ -81,5 +108,39 @@ func init() {
 	flag.IntVar(&PodDelay, "mixed.mig.pod-delay", 0, "delay in seconds between pod creation on mixed-mig testcase")
 	flag.IntVar(&SingleMigProfile, "single.mig.profile", -2, "index of the MIG profile to be used for single-mig testcase")
 	flag.StringVar(&MigInstances, "mixed.mig.instances", "-1", "comma-separated number of instances for mixed-mig testcase, defaults are for A100 GPU [2,0,1,1,0,0]")
+//	flag.IntVar(&TsPodCount, "time.slicing.pod-count", 1, "number of gpu-burn pods for time-slicing testcase (1-8)")
+	flag.StringVar(&TsInstancesCSV, "time.slicing.instances", defaultTsInstancesCSV, "comma-separated time-slice counts per pod; sum must not exceed MaxTsInstance (100)")
+	flag.IntVar(&TsMonAfterPod, "time.slicing.mon-after-pod", 0, "minimum number of pods running before monitoring starts")
 	flag.BoolVar(&NoColor, "no-color", false, "disable color output")
+}
+
+const (
+	migConfigLabel      = "nvidia.com/mig.config"
+	migConfigStateLabel = "nvidia.com/mig.config.state"
+	migConfigDisabled   = "all-disabled"
+)
+
+const timeSlicingDevicePluginConfigMapName = "device-plugin-config"
+
+const gpuProductSharedSuffix = "-SHARED"
+
+const gpuProductLabelKey = "nvidia.com/gpu.product"
+
+type timeSlicingConfigSnapshot struct {
+	hadDevicePluginConfig bool
+	devicePluginConfig    *nvidiagpuv1.DevicePluginConfig
+	gfdEnabled            *bool
+	configMapExisted      bool
+	configMapData         map[string]string
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }

--- a/pkg/mig/migtypes.go
+++ b/pkg/mig/migtypes.go
@@ -108,7 +108,7 @@ func init() {
 	flag.IntVar(&PodDelay, "mixed.mig.pod-delay", 0, "delay in seconds between pod creation on mixed-mig testcase")
 	flag.IntVar(&SingleMigProfile, "single.mig.profile", -2, "index of the MIG profile to be used for single-mig testcase")
 	flag.StringVar(&MigInstances, "mixed.mig.instances", "-1", "comma-separated number of instances for mixed-mig testcase, defaults are for A100 GPU [2,0,1,1,0,0]")
-//	flag.IntVar(&TsPodCount, "time.slicing.pod-count", 1, "number of gpu-burn pods for time-slicing testcase (1-8)")
+	// flag.IntVar(&TsPodCount, "time.slicing.pod-count", 1, "number of gpu-burn pods for time-slicing testcase (1-8)")
 	flag.StringVar(&TsInstancesCSV, "time.slicing.instances", defaultTsInstancesCSV, "comma-separated time-slice counts per pod; sum must not exceed MaxTsInstance (100)")
 	flag.IntVar(&TsMonAfterPod, "time.slicing.mon-after-pod", 0, "minimum number of pods running before monitoring starts")
 	flag.BoolVar(&NoColor, "no-color", false, "disable color output")

--- a/pkg/mig/migtypes.go
+++ b/pkg/mig/migtypes.go
@@ -108,7 +108,6 @@ func init() {
 	flag.IntVar(&PodDelay, "mixed.mig.pod-delay", 0, "delay in seconds between pod creation on mixed-mig testcase")
 	flag.IntVar(&SingleMigProfile, "single.mig.profile", -2, "index of the MIG profile to be used for single-mig testcase")
 	flag.StringVar(&MigInstances, "mixed.mig.instances", "-1", "comma-separated number of instances for mixed-mig testcase, defaults are for A100 GPU [2,0,1,1,0,0]")
-	// flag.IntVar(&TsPodCount, "time.slicing.pod-count", 1, "number of gpu-burn pods for time-slicing testcase (1-8)")
 	flag.StringVar(&TsInstancesCSV, "time.slicing.instances", defaultTsInstancesCSV, "comma-separated time-slice counts per pod; sum must not exceed MaxTsInstance (100)")
 	flag.IntVar(&TsMonAfterPod, "time.slicing.mon-after-pod", 0, "minimum number of pods running before monitoring starts")
 	flag.BoolVar(&NoColor, "no-color", false, "disable color output")

--- a/pkg/mig/migtypes.go
+++ b/pkg/mig/migtypes.go
@@ -98,7 +98,7 @@ const (
 	MaxTsSlices       int = 8 // max time-slice replicas per GPU (device plugin)
 	// MaxTsInstance is the maximum sum of per-pod time-slice counts for one GPU.
 	MaxTsInstance int = 100
-	// defaultTsInstancesCSV has MaxTsSlices entries; the first TsPodCount values are used.
+	// defaultTsInstancesCSV may have up to MaxTsSlices entries, however their sum may not exceed MaxTsInstance (100)
 	defaultTsInstancesCSV = "8" // e.g. "8,1,3,2,6,5,8,8"
 	//defaultTsMonAfterPod   int = 1 // start monitoring pods after 1 pod is running
 )

--- a/pkg/olm/operatorgroup.go
+++ b/pkg/olm/operatorgroup.go
@@ -167,7 +167,7 @@ func PullOperatorGroup(apiClient *clients.Settings, groupName, nsName string) (*
 	}
 
 	if !builder.Exists() {
-		return nil, fmt.Errorf("OperatorGroup object named %s doesn't exist", nsName)
+		return nil, fmt.Errorf("OperatorGroup object named %s doesn't exist in namespace %s", groupName, nsName)
 	}
 
 	builder.Definition = builder.Object

--- a/tests/mig/mig_test.go
+++ b/tests/mig/mig_test.go
@@ -72,6 +72,10 @@ var _ = Describe("MIG", Ordered, Label(tsparams.LabelSuite), func() {
 
 		AfterAll(func() {
 			glog.V(gpuparams.Gpu10LogLevel).Infof("cleanup in AfterAll")
+			err := mig.DeletePods(inittools.APIClient, burn.Namespace).
+				WithLabelSelector(burn.PodLabel).
+				Delete()
+			Expect(err).ToNot(HaveOccurred(), "Error deleting gpu-burn pods in AfterAll: %v", err)
 			if nfdInstance.CleanupAfterInstall && cleanupAfterTest {
 				err := nfd.Cleanup(inittools.APIClient)
 				Expect(err).ToNot(HaveOccurred(), "Error cleaning up NFD resources: %v", err)
@@ -96,6 +100,15 @@ var _ = Describe("MIG", Ordered, Label(tsparams.LabelSuite), func() {
 				Skip("Test skipped: 'mixed-mig' label not present in ginkgo label filter")
 			}
 			mig.TestMixedMIGGPUWorkload(nvidiaGPUConfig, burn, BurnImageName, WorkerNodeSelector, cleanupAfterTest)
+		})
+
+		It("Test GPU workload with timeslicing", Label("time-slicing"), func() {
+			// Skip if time-slicing label is not in the ginkgo label filter
+			if !mig.IsLabelInFilter("time-slicing") {
+				glog.V(gpuparams.GpuLogLevel).Infof("Skipping test: 'time-slicing' label not present in ginkgo label filter")
+				Skip("Test skipped: 'time-slicing' label not present in ginkgo label filter")
+			}
+			mig.TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig, burn, BurnImageName, WorkerNodeSelector, cleanupAfterTest)
 		})
 
 	})

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -245,7 +245,7 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			nfd.EnsureNFDIsInstalled(inittools.APIClient, nfdInstance, ocpVersion, gpuparams.GpuLogLevel)
 
-			if mig.IsLabelInFilter("single-mig") || mig.IsLabelInFilter("mixed-mig") || mig.IsLabelInFilter("time-slicing") {
+			if mig.AnyLabelInFilter("single-mig", "mixed-mig", "time-slicing") {
 				mig.ParseCLIParameters()
 				mig.LogCLIParameterValues()
 			}

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -149,7 +149,7 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 			glog.V(0).Infof("CleanupAfterTest: %v", cleanupAfterTest)
 
 			// if any of the following labels are present, the operator should be kept
-			labelsToCheck = []string{"operator-upgrade", "single-mig", "mixed-mig"}
+			labelsToCheck = []string{"operator-upgrade", "single-mig", "mixed-mig", "time-slicing"}
 			glog.V(0).Infof("LabelsToCheck: %v", labelsToCheck)
 
 			if cleanupAfterTest && !mig.ShouldKeepOperator(labelsToCheck) {
@@ -245,7 +245,7 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			nfd.EnsureNFDIsInstalled(inittools.APIClient, nfdInstance, ocpVersion, gpuparams.GpuLogLevel)
 
-			if mig.IsLabelInFilter("single-mig") || mig.IsLabelInFilter("mixed-mig") {
+			if mig.IsLabelInFilter("single-mig") || mig.IsLabelInFilter("mixed-mig") || mig.IsLabelInFilter("time-slicing") {
 				mig.ParseCLIParameters()
 				mig.LogCLIParameterValues()
 			}
@@ -1134,6 +1134,16 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				Skip("Test skipped: 'mixed-mig' label not present in ginkgo label filter")
 			}
 			mig.TestMixedMIGGPUWorkload(nvidiaGPUConfig, burn, BurnImageName, WorkerNodeSelector, cleanupAfterTest)
+		})
+
+		It("Test GPU workload with timeslicing", Label("time-slicing"), func() {
+			// Skip if time-slicing label is not in the ginkgo label filter
+			if !mig.IsLabelInFilter("time-slicing") {
+				glog.V(gpuparams.GpuLogLevel).Infof("Skipping test: 'time-slicing' label not present in ginkgo label filter")
+				Skip("Test skipped: 'time-slicing' label not present in ginkgo label filter")
+			}
+			cleanup := cleanupAfterTest && !mig.ShouldKeepOperator(labelsToCheck)
+			mig.TestGPUWorkloadWithTimeslicing(nvidiaGPUConfig, burn, BurnImageName, WorkerNodeSelector, cleanup)
 		})
 	})
 })

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -726,6 +726,13 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 					err)
 			}
 
+			By("Disable MIG if configured on GPU nodes")
+			migActive, err := mig.IsMig(WorkerNodeSelector)
+			Expect(err).ToNot(HaveOccurred(), "error checking MIG status on GPU nodes: %v", err)
+			if migActive {
+				mig.DisableMig(WorkerNodeSelector)
+			}
+
 			By("Create GPU Burn namespace 'test-gpu-burn'")
 			gpuBurnNsBuilder := namespace.NewBuilder(inittools.APIClient, burn.Namespace)
 			if gpuBurnNsBuilder.Exists() {


### PR DESCRIPTION
Added arguments into gpuburn.go so that special handling for time-slicing testcase can be done. Simplified NodeLabelExists in wait.go.
New constants, variables, type definitions etc in migtypes.go related to time-slicing testcase. Minor log change in operatorgroup.go, it only showed namespace name (nsName), not groupName. Adding disabling MIG into deploygpu_test.go to ensure that nvidia-ci would not fail in baremetal deployment when previous MIG testcase had failed.
Added time-slicing testcase into mig_test.go.
Added functions for new time-slicing testcase (TestGPUWorkloadWithTimeslicing) into mig.go.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end GPU burn **time-slicing** testing with slice configuration, GPU load monitoring, and per-slice log validation.
  - Extended time-slicing support for MIG-based GPU burn runs, including passing through optional runtime container arguments.
- **Bug Fixes**
  - Improved node selection/waiting to correctly match required label key/value pairs.
  - Enhanced OperatorGroup error messages with clearer namespace context.
- **Tests**
  - Added time-slicing coverage to deployment gating and extended cleanup to remove time-slicing GPU burn pods.
- **Documentation**
  - Reformatted and refreshed README setup/run instructions and example commands (including MPS/MIG/time-slicing label guidance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->