### PR TITLE
Fixing the wrong timeout that can appear when deployment is missing.

### DIFF
--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/nvidiagpu"
 	"github.com/rh-ecosystem-edge/nvidia-ci/pkg/olm"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -117,12 +118,20 @@ func DeploymentCreated(apiClient *clients.Settings, deploymentName, deploymentNa
 		context.TODO(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			deploymentPulled, err := deployment.Pull(apiClient, deploymentName, deploymentNamespace)
 			if err != nil {
-				// Missing Deployment is expected until OLM creates it; returning an error would abort
-				// PollUntilContextTimeout immediately instead of waiting for timeout.
+				// Missing Deployment is expected until OLM creates it. deployment.Pull wraps absence as
+				// a custom error (not always apierrors.IsNotFound); only those should keep polling.
+				missingMsg := fmt.Sprintf("deployment object %s doesn't exist in namespace %s",
+					deploymentName, deploymentNamespace)
+				if apierrors.IsNotFound(err) || err.Error() == missingMsg {
+					glog.V(gpuparams.GpuLogLevel).Infof(
+						"Deployment '%s' not yet present in namespace '%s': %v",
+						deploymentName, deploymentNamespace, err)
+					return false, nil
+				}
 				glog.V(gpuparams.GpuLogLevel).Infof(
-					"Deployment '%s' not yet present in namespace '%s': %v",
+					"Deployment '%s' pull from cluster namespace '%s' error: %v",
 					deploymentName, deploymentNamespace, err)
-				return false, nil
+				return false, err
 			}
 
 			if deploymentPulled.Exists() {

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -113,25 +113,21 @@ func CSVSucceeded(apiClient *clients.Settings, csvName, csvNamespace string, pol
 // DeploymentCreated waits for a defined period of time for deployment to be created.
 func DeploymentCreated(apiClient *clients.Settings, deploymentName, deploymentNamespace string, pollInterval,
 	timeout time.Duration) bool {
-	// Note: the value for boolean variable "immediate" is false here, meaning check AFTER polling interval
-	//       on the very first try.  Otherwise the first check was causing an error and failing testcase.
 	err := wait.PollUntilContextTimeout(
-		context.TODO(), pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
-			var err error
+		context.TODO(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			deploymentPulled, err := deployment.Pull(apiClient, deploymentName, deploymentNamespace)
-
 			if err != nil {
-				glog.V(gpuparams.GpuLogLevel).Infof("Deployment '%s' pull from cluster namespace '%s' error:"+
-					" %v", deploymentName, deploymentNamespace, err)
-
-				return false, err
+				// Missing Deployment is expected until OLM creates it; returning an error would abort
+				// PollUntilContextTimeout immediately instead of waiting for timeout.
+				glog.V(gpuparams.GpuLogLevel).Infof(
+					"Deployment '%s' not yet present in namespace '%s': %v",
+					deploymentName, deploymentNamespace, err)
+				return false, nil
 			}
 
 			if deploymentPulled.Exists() {
 				glog.V(gpuparams.GpuLogLevel).Infof("Deployment '%s' in namespace '%s' has been created",
 					deploymentPulled.Object.Name, deploymentNamespace)
-
-				// this exists out of the wait.PollImmediate().
 				return true, nil
 			}
 

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -118,11 +118,8 @@ func DeploymentCreated(apiClient *clients.Settings, deploymentName, deploymentNa
 		context.TODO(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			deploymentPulled, err := deployment.Pull(apiClient, deploymentName, deploymentNamespace)
 			if err != nil {
-				// Missing Deployment is expected until OLM creates it. deployment.Pull wraps absence as
-				// a custom error (not always apierrors.IsNotFound); only those should keep polling.
-				missingMsg := fmt.Sprintf("deployment object %s doesn't exist in namespace %s",
-					deploymentName, deploymentNamespace)
-				if apierrors.IsNotFound(err) || err.Error() == missingMsg {
+				// Missing Deployment is expected until OLM creates it; keep polling only for NotFound.
+				if apierrors.IsNotFound(err) {
 					glog.V(gpuparams.GpuLogLevel).Infof(
 						"Deployment '%s' not yet present in namespace '%s': %v",
 						deploymentName, deploymentNamespace, err)

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -120,7 +120,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	}
 
 	if !builder.Exists() {
-		return nil, fmt.Errorf("deployment object %s doesn't exist in namespace %s", name, nsname)
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, name)
 	}
 
 	builder.Definition = builder.Object


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment creation checks now start polling immediately for faster detection.
  * If the deployment pull reports Kubernetes “not found,” the check is treated as non-fatal and continues polling.
  * Any other pull failure still stops polling.
  * Polling continues until the deployment is detected or the configured timeout is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->