### PR TITLE
Optimize GPU burn pod wait logic

### DIFF
--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -937,15 +937,39 @@ func DeployGPUWorkload(
 func waitForGPUBurnPodToComplete(gpuMigPodPulled *pod.Builder, namespace string) {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Wait for GPU burn pod to complete"))
 
-	err := gpuMigPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
+	// Refresh pod state — the caller's snapshot may be stale.
+	gpuMigPodPulled, err := pod.Pull(inittools.APIClient, gpuMigPodPulled.Definition.Name, namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to pull gpu-burn pod in namespace '%s': %v", namespace, err)
+
+	// Early-exit: pod already completed before we started waiting.
+	if gpuMigPodPulled.Object.Status.Phase == corev1.PodSucceeded {
+		glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod already in Succeeded phase, skipping wait")
+
+		return
+	}
+
+	// Phase 1: verify the pod can be scheduled onto a GPU node. Fail fast if not.
+	err = gpuMigPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
 	Expect(err).ToNot(HaveOccurred(), "gpu-burn MIG pod in namespace '%s' was not scheduled "+
 		"(no GPU node available): %v", namespace, err)
 	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG is scheduled onto a GPU node")
 
-	err = gpuMigPodPulled.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
-	Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in namespace '%s' "+
-		"to reach Running phase (image pull may have taken too long): %v", namespace, err)
-	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG now in Running phase")
+	// Phase 2: wait for Running or Succeeded, tolerating time needed for image pull and fast completions.
+	err = gpuMigPodPulled.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
+	if err != nil {
+		// Pull a fresh snapshot for diagnostic logging only.
+		pod2, err2 := pod.Pull(inittools.APIClient, gpuMigPodPulled.Definition.Name, namespace)
+		if err2 == nil {
+			glog.V(gpuparams.Gpu10LogLevel).Infof("Pod %s did not reach Running or Succeeded: %s (%s). Error: %v",
+				pod2.Definition.Name, pod2.Object.Status.Phase, pod2.Object.Status.Reason, err)
+			logPodEvents(pod2.Definition.Name, namespace)
+		}
+
+		Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in namespace '%s' "+
+			"to reach Running phase (image pull may have taken too long): %v", namespace, err)
+	}
+
+	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG now in Running or Succeeded phase")
 
 	glog.V(gpuparams.Gpu10LogLevel).Infof("Wait for up to %s for gpu-burn pod to complete", nvidiagpu.BurnPodSuccessTimeout)
 	err = gpuMigPodPulled.WaitUntilInStatus(corev1.PodSucceeded, nvidiagpu.BurnPodSuccessTimeout)
@@ -989,7 +1013,7 @@ func isRunning(gpuPod *pod.Builder, namespace string) {
 	// This is to avoid waiting, if the pod is already in Running or Succeeded phase.
 	// If pod was Completed (or Running) already, there's no need to wait.
 	// Avoiding the timeout in case it is Completed already is preferred.
-	_, err := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
+	gpuPod, err := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
 	Expect(err).ToNot(HaveOccurred(), "Pod %s does not exist in namespace %s with error: %v", gpuPod.Definition.Name, namespace, err)
 	if gpuPod.Object.Status.Phase == corev1.PodRunning || gpuPod.Object.Status.Phase == corev1.PodSucceeded {
 		return
@@ -1001,19 +1025,20 @@ func isRunning(gpuPod *pod.Builder, namespace string) {
 		"(no GPU node available): %v", namespace, err)
 	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG is scheduled onto a GPU node")
 
-	// Phase 2: wait for Running, tolerating time needed for image pull.
-	err = gpuPod.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
-	var err2 error
-	var pod2 *pod.Builder
+	// Phase 2: wait for Running or Succeeded, tolerating time needed for image pull and fast completions.
+	err = gpuPod.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
 	if err != nil {
-		// pod was scheduled but did not reach Running — likely image pull issue
-		// Using pod2 to avoid confusion with previous pod pull
-		pod2, err2 = pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
-		Expect(err2).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
+		// pod was scheduled but did not reach Running or Succeeded — likely image pull issue.
+		// Pull a fresh snapshot for diagnostic logging only.
+		pod2, err2 := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
+		if err2 == nil {
+			glog.V(gpuparams.Gpu10LogLevel).Infof("Pod %s did not reach Running or Succeeded: %s (%s). Error: %v",
+				pod2.Definition.Name, pod2.Object.Status.Phase, pod2.Object.Status.Reason, err)
+			logPodEvents(pod2.Definition.Name, namespace)
+		}
+
+		Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
 			"namespace '%s' to reach Running phase (image pull may have taken too long): %v", namespace, err)
-		glog.V(gpuparams.Gpu10LogLevel).Infof("Pod %s did not reach Running: %s (%s). Error: %v, Error2: %v",
-			pod2.Definition.Name, pod2.Object.Status.Phase, pod2.Object.Status.Reason, err, err2)
-		logPodEvents(pod2.Definition.Name, namespace)
 	}
 }
 

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -932,11 +932,19 @@ func DeployGPUWorkload(
 
 // waitForGPUBurnPodToComplete waits for the GPU burn pod to reach Running phase,
 // then waits for it to complete and reach Succeeded phase.
+// It uses a two-phase timeout: Phase 1 checks scheduling (fast fail if no GPU node),
+// Phase 2 waits for Running (tolerates slow image pulls).
 func waitForGPUBurnPodToComplete(gpuMigPodPulled *pod.Builder, namespace string) {
 	glog.V(gpuparams.Gpu10LogLevel).Infof("%s", colorLog(colorCyan+colorBold, "Wait for GPU burn pod to complete"))
-	err := gpuMigPodPulled.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
-	Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
-		"namespace '%s' to go to Running phase: %v", namespace, err)
+
+	err := gpuMigPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
+	Expect(err).ToNot(HaveOccurred(), "gpu-burn MIG pod in namespace '%s' was not scheduled "+
+		"(no GPU node available): %v", namespace, err)
+	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG is scheduled onto a GPU node")
+
+	err = gpuMigPodPulled.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
+	Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in namespace '%s' "+
+		"to reach Running phase (image pull may have taken too long): %v", namespace, err)
 	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG now in Running phase")
 
 	glog.V(gpuparams.Gpu10LogLevel).Infof("Wait for up to %s for gpu-burn pod to complete", nvidiagpu.BurnPodSuccessTimeout)
@@ -972,8 +980,10 @@ func logPodEvents(podName, namespace string) {
 	}
 }
 
-// isRunning checks and waits for the GPU burn pod to reach the Running phase.
-// It first checks it quickly and if necessary, it waits for it to reach the Running phase.
+// isRunning checks and waits for the GPU burn pod to reach the Running phase using a two-phase
+// timeout: Phase 1 checks that the pod is scheduled (fast fail if no GPU node), Phase 2 waits
+// for Running (tolerates slow image pulls).
+// It first checks quickly and if the pod is already Running or Succeeded, it returns immediately.
 // Log validation ensures that the logs are from the pod that was created at the start of the test.
 func isRunning(gpuPod *pod.Builder, namespace string) {
 	// This is to avoid waiting, if the pod is already in Running or Succeeded phase.
@@ -984,18 +994,24 @@ func isRunning(gpuPod *pod.Builder, namespace string) {
 	if gpuPod.Object.Status.Phase == corev1.PodRunning || gpuPod.Object.Status.Phase == corev1.PodSucceeded {
 		return
 	}
-	// Waiting for the pod to reach Running phase, if it was not already.
-	// If the pod is left in Pending state, timeout will occur.
+
+	// Phase 1: verify the pod can be scheduled onto a GPU node. Fail fast if not.
+	err = gpuPod.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
+	Expect(err).ToNot(HaveOccurred(), "gpu-burn MIG pod in namespace '%s' was not scheduled "+
+		"(no GPU node available): %v", namespace, err)
+	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG is scheduled onto a GPU node")
+
+	// Phase 2: wait for Running, tolerating time needed for image pull.
 	err = gpuPod.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
 	var err2 error
 	var pod2 *pod.Builder
 	if err != nil {
-		// pod exists, but is not running
+		// pod was scheduled but did not reach Running — likely image pull issue
 		// Using pod2 to avoid confusion with previous pod pull
 		pod2, err2 = pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
 		Expect(err2).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
-			"namespace '%s' to go to Running phase: %v\n Pod is likely Pending for some reason", namespace, err)
-		glog.V(gpuparams.Gpu10LogLevel).Infof("Pod %s is likely Pending for some reason: %s (%s). Error: %v, Error2: %v",
+			"namespace '%s' to reach Running phase (image pull may have taken too long): %v", namespace, err)
+		glog.V(gpuparams.Gpu10LogLevel).Infof("Pod %s did not reach Running: %s (%s). Error: %v, Error2: %v",
 			pod2.Definition.Name, pod2.Object.Status.Phase, pod2.Object.Status.Reason, err, err2)
 		logPodEvents(pod2.Definition.Name, namespace)
 	}

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -948,10 +948,10 @@ func waitForGPUBurnPodToComplete(gpuMigPodPulled *pod.Builder, namespace string)
 		return
 	}
 
-	// Phase 1: verify the pod can be scheduled onto a GPU node. Fail fast if not.
+	// Phase 1: confirm the pod is scheduled within the timeout window.
 	err = gpuMigPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
 	Expect(err).ToNot(HaveOccurred(), "gpu-burn MIG pod in namespace '%s' was not scheduled "+
-		"(no GPU node available): %v", namespace, err)
+		"within the timeout (scheduler may be busy or pod may have failed early): %v", namespace, err)
 	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG is scheduled onto a GPU node")
 
 	// Phase 2: wait for Running or Succeeded, tolerating time needed for image pull and fast completions.
@@ -965,8 +965,8 @@ func waitForGPUBurnPodToComplete(gpuMigPodPulled *pod.Builder, namespace string)
 			logPodEvents(pod2.Definition.Name, namespace)
 		}
 
-		Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in namespace '%s' "+
-			"to reach Running phase (image pull may have taken too long): %v", namespace, err)
+		Expect(err).ToNot(HaveOccurred(), "gpu-burn pod with MIG in namespace '%s' did not reach "+
+			"Running or Succeeded phase (pod may have failed or image pull may have taken too long): %v", namespace, err)
 	}
 
 	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG now in Running or Succeeded phase")
@@ -1021,16 +1021,15 @@ func isRunning(gpuPod *pod.Builder, namespace string) {
 		return
 	}
 
-	// Phase 1: verify the pod can be scheduled onto a GPU node. Fail fast if not.
+	// Phase 1: confirm the pod is scheduled within the timeout window.
 	err = gpuPod.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
 	Expect(err).ToNot(HaveOccurred(), "gpu-burn MIG pod in namespace '%s' was not scheduled "+
-		"(no GPU node available): %v", namespace, err)
+		"within the timeout (scheduler may be busy or pod may have failed early): %v", namespace, err)
 	glog.V(gpuparams.Gpu10LogLevel).Infof("gpu-burn pod with MIG is scheduled onto a GPU node")
 
 	// Phase 2: wait for Running or Succeeded, tolerating time needed for image pull and fast completions.
 	err = gpuPod.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
 	if err != nil {
-		// pod was scheduled but did not reach Running or Succeeded — likely image pull issue.
 		// Pull a fresh snapshot for diagnostic logging only.
 		pod2, err2 := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
 		if err2 == nil {
@@ -1039,8 +1038,8 @@ func isRunning(gpuPod *pod.Builder, namespace string) {
 			logPodEvents(pod2.Definition.Name, namespace)
 		}
 
-		Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod with MIG in "+
-			"namespace '%s' to reach Running phase (image pull may have taken too long): %v", namespace, err)
+		Expect(err).ToNot(HaveOccurred(), "gpu-burn pod with MIG in namespace '%s' did not reach "+
+			"Running or Succeeded phase (pod may have failed or image pull may have taken too long): %v", namespace, err)
 	}
 }
 

--- a/pkg/mig/mig.go
+++ b/pkg/mig/mig.go
@@ -1013,8 +1013,10 @@ func isRunning(gpuPod *pod.Builder, namespace string) {
 	// This is to avoid waiting, if the pod is already in Running or Succeeded phase.
 	// If pod was Completed (or Running) already, there's no need to wait.
 	// Avoiding the timeout in case it is Completed already is preferred.
-	gpuPod, err := pod.Pull(inittools.APIClient, gpuPod.Definition.Name, namespace)
-	Expect(err).ToNot(HaveOccurred(), "Pod %s does not exist in namespace %s with error: %v", gpuPod.Definition.Name, namespace, err)
+	// Save the pod name before the pull so we can reference it safely even if Pull returns nil.
+	podName := gpuPod.Definition.Name
+	gpuPod, err := pod.Pull(inittools.APIClient, podName, namespace)
+	Expect(err).ToNot(HaveOccurred(), "Pod %s does not exist in namespace %s with error: %v", podName, namespace, err)
 	if gpuPod.Object.Status.Phase == corev1.PodRunning || gpuPod.Object.Status.Phase == corev1.PodSucceeded {
 		return
 	}

--- a/pkg/nvidiagpu/consts.go
+++ b/pkg/nvidiagpu/consts.go
@@ -53,13 +53,14 @@ const (
 
 	BurnPodCreationTimeout = 5 * time.Minute
 
-	// BurnPodScheduledTimeout is the Phase 1 timeout: how long to wait for the pod to be
-	// scheduled onto a GPU node. Scheduling failure means no GPU node is available and
-	// the test should fail fast without waiting for image pull.
+	// BurnPodScheduledTimeout is the Phase 1 timeout: how long to wait for scheduling
+	// confirmation (PodScheduled=True). A phase-1 failure means the scheduler did not
+	// place the pod within the window; it does not necessarily mean no GPU node exists.
 	BurnPodScheduledTimeout = 1 * time.Minute
 
 	// BurnPodRunningTimeout is the Phase 2 timeout: how long to wait for the pod to reach
-	// Running phase after scheduling is confirmed. This covers slow image pulls.
+	// Running or Succeeded phase after scheduling is confirmed. This covers slow image pulls
+	// and pods that complete very quickly between poll cycles.
 	BurnPodRunningTimeout = 8 * time.Minute
 	BurnPodSuccessTimeout = 8 * time.Minute
 

--- a/pkg/nvidiagpu/consts.go
+++ b/pkg/nvidiagpu/consts.go
@@ -53,6 +53,13 @@ const (
 
 	BurnPodCreationTimeout = 5 * time.Minute
 
+	// BurnPodScheduledTimeout is the Phase 1 timeout: how long to wait for the pod to be
+	// scheduled onto a GPU node. Scheduling failure means no GPU node is available and
+	// the test should fail fast without waiting for image pull.
+	BurnPodScheduledTimeout = 1 * time.Minute
+
+	// BurnPodRunningTimeout is the Phase 2 timeout: how long to wait for the pod to reach
+	// Running phase after scheduling is confirmed. This covers slow image pulls.
 	BurnPodRunningTimeout = 8 * time.Minute
 	BurnPodSuccessTimeout = 8 * time.Minute
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -313,6 +313,12 @@ func (builder *Builder) WaitUntilScheduled(timeout time.Duration) error {
 				return false, nil
 			}
 
+			// Pod failed before or during scheduling — no point waiting further.
+			if updatedPod.Status.Phase == corev1.PodFailed {
+				return false, fmt.Errorf("pod %s/%s failed before being scheduled (reason: %s)",
+					updatedPod.Namespace, updatedPod.Name, updatedPod.Status.Reason)
+			}
+
 			// If the pod jumped straight to Running (or beyond), scheduling is implicitly done.
 			if updatedPod.Status.Phase == corev1.PodRunning || updatedPod.Status.Phase == corev1.PodSucceeded {
 				return true, nil
@@ -325,6 +331,37 @@ func (builder *Builder) WaitUntilScheduled(timeout time.Duration) error {
 			}
 
 			return false, nil
+		})
+}
+
+// WaitUntilRunningOrSucceeded waits until the pod reaches Running or Succeeded phase within the
+// given timeout. This is used as phase-2 of the GPU burn wait flow: a pod that completes very
+// quickly between poll cycles will be in Succeeded rather than Running, and must not be treated
+// as a timeout failure.
+func (builder *Builder) WaitUntilRunningOrSucceeded(timeout time.Duration) error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	glog.V(100).Infof("Waiting for the defined period until pod %s in namespace %s is Running or Succeeded",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), pollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
+			updatedPod, err := builder.apiClient.Pods(builder.Definition.Namespace).Get(
+				ctx, builder.Definition.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			// Pod failed — short-circuit immediately instead of waiting out the full timeout.
+			if updatedPod.Status.Phase == corev1.PodFailed {
+				return false, fmt.Errorf("pod %s/%s failed while waiting for Running or Succeeded (reason: %s)",
+					updatedPod.Namespace, updatedPod.Name, updatedPod.Status.Reason)
+			}
+
+			return updatedPod.Status.Phase == corev1.PodRunning ||
+				updatedPod.Status.Phase == corev1.PodSucceeded, nil
 		})
 }
 
@@ -343,6 +380,12 @@ func (builder *Builder) WaitUntilInStatus(status corev1.PodPhase, timeout time.D
 				ctx, builder.Definition.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
+			}
+
+			// Pod failed — short-circuit immediately instead of waiting out the full timeout.
+			if updatePod.Status.Phase == corev1.PodFailed {
+				return false, fmt.Errorf("pod %s/%s failed while waiting for phase %s (reason: %s)",
+					updatePod.Namespace, updatePod.Name, status, updatePod.Status.Reason)
 			}
 
 			return updatePod.Status.Phase == status, nil

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -313,21 +313,25 @@ func (builder *Builder) WaitUntilScheduled(timeout time.Duration) error {
 				return false, nil
 			}
 
-			// Pod failed before or during scheduling — no point waiting further.
-			if updatedPod.Status.Phase == corev1.PodFailed {
-				return false, fmt.Errorf("pod %s/%s failed before being scheduled (reason: %s)",
-					updatedPod.Namespace, updatedPod.Name, updatedPod.Status.Reason)
-			}
+			// Check all success conditions first so a pod that was scheduled and then
+			// immediately failed is not misclassified as a scheduling failure.
 
-			// If the pod jumped straight to Running (or beyond), scheduling is implicitly done.
-			if updatedPod.Status.Phase == corev1.PodRunning || updatedPod.Status.Phase == corev1.PodSucceeded {
-				return true, nil
-			}
-
+			// PodScheduled=True confirms the scheduler placed the pod on a node.
 			for _, cond := range updatedPod.Status.Conditions {
 				if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionTrue {
 					return true, nil
 				}
+			}
+
+			// If the pod jumped straight to Running or Succeeded, scheduling is implicitly done.
+			if updatedPod.Status.Phase == corev1.PodRunning || updatedPod.Status.Phase == corev1.PodSucceeded {
+				return true, nil
+			}
+
+			// Only classify as a scheduling failure if PodScheduled was never set to True.
+			if updatedPod.Status.Phase == corev1.PodFailed {
+				return false, fmt.Errorf("pod %s/%s failed without being scheduled (reason: %s)",
+					updatedPod.Namespace, updatedPod.Name, updatedPod.Status.Reason)
 			}
 
 			return false, nil

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -382,13 +382,19 @@ func (builder *Builder) WaitUntilInStatus(status corev1.PodPhase, timeout time.D
 				return false, nil
 			}
 
-			// Pod failed — short-circuit immediately instead of waiting out the full timeout.
+			// Check the requested phase first — this preserves support for callers that
+			// explicitly wait for PodFailed (e.g. WaitUntilInStatus(corev1.PodFailed, ...)).
+			if updatePod.Status.Phase == status {
+				return true, nil
+			}
+
+			// Pod failed for any other requested phase — short-circuit instead of timing out.
 			if updatePod.Status.Phase == corev1.PodFailed {
 				return false, fmt.Errorf("pod %s/%s failed while waiting for phase %s (reason: %s)",
 					updatePod.Namespace, updatePod.Name, status, updatePod.Status.Reason)
 			}
 
-			return updatePod.Status.Phase == status, nil
+			return false, nil
 		})
 }
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -293,6 +293,41 @@ func (builder *Builder) WaitUntilRunning(timeout time.Duration) error {
 	return builder.WaitUntilInStatus(corev1.PodRunning, timeout)
 }
 
+// WaitUntilScheduled waits until the pod has been scheduled onto a node, indicated by the
+// PodScheduled condition being True, or until the pod has already reached Running phase
+// directly (edge case where scheduling and start happen between poll cycles).
+// If the timeout expires before scheduling is confirmed, an error is returned.
+func (builder *Builder) WaitUntilScheduled(timeout time.Duration) error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	glog.V(100).Infof("Waiting for the defined period until pod %s in namespace %s is scheduled",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), pollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
+			updatedPod, err := builder.apiClient.Pods(builder.Definition.Namespace).Get(
+				ctx, builder.Definition.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			// If the pod jumped straight to Running (or beyond), scheduling is implicitly done.
+			if updatedPod.Status.Phase == corev1.PodRunning || updatedPod.Status.Phase == corev1.PodSucceeded {
+				return true, nil
+			}
+
+			for _, cond := range updatedPod.Status.Conditions {
+				if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionTrue {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		})
+}
+
 // WaitUntilInStatus waits for the duration of the defined timeout or until the pod gets to a specific status.
 func (builder *Builder) WaitUntilInStatus(status corev1.PodPhase, timeout time.Duration) error {
 	if valid, err := builder.validate(); !valid {

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -844,10 +844,16 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				}
 			}()
 
-			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to be in Running phase", nvidiagpu.BurnPodRunningTimeout))
+			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to be scheduled onto a GPU node (Phase 1)", nvidiagpu.BurnPodScheduledTimeout))
+			err = gpuPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
+			Expect(err).ToNot(HaveOccurred(), "gpu-burn pod in namespace '%s' was not scheduled "+
+				"(no GPU node available): %v", burn.Namespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod is scheduled onto a GPU node")
+
+			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to be in Running phase (Phase 2)", nvidiagpu.BurnPodRunningTimeout))
 			err = gpuPodPulled.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
-			Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod in "+
-				"namespace '%s' to go to Running phase:  %v ", burn.Namespace, err)
+			Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod in namespace '%s' "+
+				"to reach Running phase (image pull may have taken too long): %v", burn.Namespace, err)
 			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running phase")
 
 			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to run to completion and be in Succeeded phase/Completed status", nvidiagpu.BurnPodSuccessTimeout))
@@ -1079,10 +1085,16 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				}
 			}()
 
-			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to be in Running phase", nvidiagpu.RedeployedBurnPodRunningTimeout))
+			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to be scheduled onto a GPU node (Phase 1)", nvidiagpu.BurnPodScheduledTimeout))
+			err = gpuBurnPod2Pulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
+			Expect(err).ToNot(HaveOccurred(), "re-deployed gpu-burn pod in namespace '%s' was not scheduled "+
+				"(no GPU node available after upgrade): %v", burn.Namespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("re-deployed gpu-burn pod is scheduled onto a GPU node")
+
+			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to be in Running phase (Phase 2)", nvidiagpu.RedeployedBurnPodRunningTimeout))
 			err = gpuBurnPod2Pulled.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.RedeployedBurnPodRunningTimeout)
-			Expect(err).ToNot(HaveOccurred(), "timeout waiting for re-deployed gpu-burn pod in "+
-				"namespace '%s' to go to Running phase:  %v ", burn.Namespace, err)
+			Expect(err).ToNot(HaveOccurred(), "timeout waiting for re-deployed gpu-burn pod in namespace '%s' "+
+				"to reach Running phase (image pull may have taken too long): %v", burn.Namespace, err)
 			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running phase")
 
 			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to run to completion and be in Succeeded phase/Completed status", nvidiagpu.RedeployedBurnPodSuccessTimeout))

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -850,11 +850,11 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				"(no GPU node available): %v", burn.Namespace, err)
 			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod is scheduled onto a GPU node")
 
-			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to be in Running phase (Phase 2)", nvidiagpu.BurnPodRunningTimeout))
-			err = gpuPodPulled.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.BurnPodRunningTimeout)
+			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to be in Running or Succeeded phase (Phase 2)", nvidiagpu.BurnPodRunningTimeout))
+			err = gpuPodPulled.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
 			Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod in namespace '%s' "+
-				"to reach Running phase (image pull may have taken too long): %v", burn.Namespace, err)
-			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running phase")
+				"to reach Running or Succeeded phase (image pull may have taken too long): %v", burn.Namespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running or Succeeded phase")
 
 			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to run to completion and be in Succeeded phase/Completed status", nvidiagpu.BurnPodSuccessTimeout))
 			err = gpuPodPulled.WaitUntilInStatus(corev1.PodSucceeded, nvidiagpu.BurnPodSuccessTimeout)
@@ -1091,11 +1091,11 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				"(no GPU node available after upgrade): %v", burn.Namespace, err)
 			glog.V(gpuparams.GpuLogLevel).Infof("re-deployed gpu-burn pod is scheduled onto a GPU node")
 
-			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to be in Running phase (Phase 2)", nvidiagpu.RedeployedBurnPodRunningTimeout))
-			err = gpuBurnPod2Pulled.WaitUntilInStatus(corev1.PodRunning, nvidiagpu.RedeployedBurnPodRunningTimeout)
+			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to be in Running or Succeeded phase (Phase 2)", nvidiagpu.RedeployedBurnPodRunningTimeout))
+			err = gpuBurnPod2Pulled.WaitUntilRunningOrSucceeded(nvidiagpu.RedeployedBurnPodRunningTimeout)
 			Expect(err).ToNot(HaveOccurred(), "timeout waiting for re-deployed gpu-burn pod in namespace '%s' "+
-				"to reach Running phase (image pull may have taken too long): %v", burn.Namespace, err)
-			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running phase")
+				"to reach Running or Succeeded phase (image pull may have taken too long): %v", burn.Namespace, err)
+			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running or Succeeded phase")
 
 			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to run to completion and be in Succeeded phase/Completed status", nvidiagpu.RedeployedBurnPodSuccessTimeout))
 			err = gpuBurnPod2Pulled.WaitUntilInStatus(corev1.PodSucceeded, nvidiagpu.RedeployedBurnPodSuccessTimeout)

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -852,8 +852,8 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to be in Running or Succeeded phase (Phase 2)", nvidiagpu.BurnPodRunningTimeout))
 			err = gpuPodPulled.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
-			Expect(err).ToNot(HaveOccurred(), "timeout waiting for gpu-burn pod in namespace '%s' "+
-				"to reach Running or Succeeded phase (image pull may have taken too long): %v", burn.Namespace, err)
+			Expect(err).ToNot(HaveOccurred(), "gpu-burn pod in namespace '%s' did not reach Running or "+
+				"Succeeded phase (pod may have failed or image pull may have taken too long): %v", burn.Namespace, err)
 			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running or Succeeded phase")
 
 			By(fmt.Sprintf("Wait for up to %s for gpu-burn pod to run to completion and be in Succeeded phase/Completed status", nvidiagpu.BurnPodSuccessTimeout))
@@ -1093,8 +1093,8 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to be in Running or Succeeded phase (Phase 2)", nvidiagpu.RedeployedBurnPodRunningTimeout))
 			err = gpuBurnPod2Pulled.WaitUntilRunningOrSucceeded(nvidiagpu.RedeployedBurnPodRunningTimeout)
-			Expect(err).ToNot(HaveOccurred(), "timeout waiting for re-deployed gpu-burn pod in namespace '%s' "+
-				"to reach Running or Succeeded phase (image pull may have taken too long): %v", burn.Namespace, err)
+			Expect(err).ToNot(HaveOccurred(), "re-deployed gpu-burn pod in namespace '%s' did not reach Running or "+
+				"Succeeded phase (pod may have failed or image pull may have taken too long): %v", burn.Namespace, err)
 			glog.V(gpuparams.GpuLogLevel).Infof("gpu-burn pod now in Running or Succeeded phase")
 
 			By(fmt.Sprintf("Wait for up to %s for re-deployed burn pod to run to completion and be in Succeeded phase/Completed status", nvidiagpu.RedeployedBurnPodSuccessTimeout))


### PR DESCRIPTION
The current GPU burn test waits for the pod to reach Running state using a single timeout. This is suboptimal because reaching Running requires image pull, which can be slow. The more critical early check is whether the pod can be scheduled onto a GPU node at all — this indicates that a GPU node has been discovered by the cluster.

A previous CI run failed because the pod was stuck in image Pulling and timed out before ever reaching Running, even though scheduling had succeeded and the pod was progressing normally.

Problem

The current single-timeout approach does not distinguish between two distinct failure modes:
Scheduling failure — no GPU node is available; the pod cannot be placed. This should fail fast.
Image pull delay — the pod is scheduled but the container image is taking time to pull. This is expected and should be tolerated with a longer timeout.
By conflating both phases into one timeout, the test either fails too early (cutting off a legitimate image pull) or wastes time waiting for a pod that will never be scheduled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU workload startup checks by separating scheduling delays from container startup delays.
  * GPU placement failures now fail faster with clearer diagnostics when available.
  * Workloads that complete successfully during startup validation are now handled correctly.
  * Image-pull delays continue to receive the appropriate additional wait time.
  * Preserved the original wait failure when diagnostic collection also encounters an error.
  * Applied the same improved handling to mixed-GPU configurations and post-upgrade validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->