### PR TITLE
Signed dashboard support for master runs

### DIFF
--- a/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
+++ b/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
@@ -42,7 +42,7 @@ def build_test_result_regex(job_suffix=""):
                     and the "master" variant is excluded.
     """
     if job_suffix:
-        gpu_version_pattern = r"\d+-\d+-x"
+        gpu_version_pattern = r"\d+-\d+-x|master"
         suffix = re.escape(job_suffix)
     else:
         gpu_version_pattern = r"\d+-\d+-x|master"
@@ -435,7 +435,7 @@ def process_tests_for_pr(pr_number: str, results_by_ocp: Dict[str, Dict[str, Any
         results_by_ocp[ocp_version]["job_history_links"].add(job_history_url)
 
         # Determine if this is a bundle test (job ends with '-master') or release test
-        if job_name.endswith('-master'):
+        if gpu_suffix == 'master':
             results_by_ocp[ocp_version]["bundle_tests"].append(result.to_dict())
         else:
             # Only include in release tests if it has exact semantic versions and is not ABORTED


### PR DESCRIPTION
Before:
<img width="1394" height="543" alt="2026-09-02T16:48:00,743027685+02:00" src="https://github.com/user-attachments/assets/e0a1a8a3-031c-4726-8df9-0c2087cc9173" />

After:
<img width="1387" height="606" alt="2026-09-02T16:48:09,924421692+02:00" src="https://github.com/user-attachments/assets/4fb4356c-702e-4f34-8d5a-072f2a9c5f21" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU version matching for jobs using a specified job suffix, including `master` versions.
  * Corrected bundle-test classification to recognize GPU version suffixes consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->