### PR TITLE
Add a new artifact for driver branch version

### DIFF
--- a/pkg/global/const.go
+++ b/pkg/global/const.go
@@ -2,7 +2,8 @@ package global
 
 const (
 	// not related to NFD but common consts between gpu and nno
-	UndefinedValue       = "undefined"
-	OperatorVersionFile  = "operator.version"
-	OpenShiftVersionFile = "ocp.version"
+	UndefinedValue           = "undefined"
+	OperatorVersionFile      = "operator.version"
+	OpenShiftVersionFile     = "ocp.version"
+	DriverBranchVersionsFile = "driver.branches"
 )

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -680,6 +680,11 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				Expect(err).ToNot(HaveOccurred(), "Failed to discover precompiled driver version: %v", err)
 				glog.V(gpuparams.GpuLogLevel).Infof("Discovered precompiled driver version: %s", driverVersion)
 
+				if err := inittools.GeneralConfig.WriteReport(
+					DriverBranchVersionsFile, []byte(driverVersion+"\n")); err != nil {
+					glog.Error("Error writing driver branch versions file: ", err)
+				}
+
 				precompiledOps := []map[string]interface{}{
 					{"op": "add", "path": "/spec/driver/usePrecompiled", "value": true},
 					{"op": "add", "path": "/spec/driver/repository", "value": nvidiagpu.PrecompiledDriverRepoField},


### PR DESCRIPTION
In order to display driver branch versions tested in the [new signed/precompiled e2e dashboard](https://rh-ecosystem-edge.github.io/nvidia-ci/gpu_operator_signed_matrix.html) we need to capture them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - NVIDIA GPU deployment reports now include the discovered precompiled driver version in the `driver.branches` report file.
  - This provides additional driver-version details for reviewing deployment results and troubleshooting.

- **Bug Fixes**
  - Improved error reporting when the driver version cannot be written to the deployment report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->