### PR TITLE
Precompiled dashboard: Fix merge ordering

### DIFF
--- a/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
+++ b/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
@@ -547,8 +547,9 @@ def merge_release_tests(
 
     for item in existing_tests:
         result = TestResult(**item)
-        version_key = get_version_key(result)
-        results_by_version.setdefault(version_key, []).append(result)
+        if result.has_exact_versions() and result.test_status != STATUS_ABORTED:
+            version_key = get_version_key(result)
+            results_by_version.setdefault(version_key, []).append(result)
 
     # Keep exactly one result per version key
     final_results = []

--- a/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
+++ b/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
@@ -534,22 +534,21 @@ def merge_release_tests(
 
     Note: Both inputs are filtered to exclude ABORTED and non-exact semantic versions.
     """
-    # Group all results by version combination
+    # Group all results by version combination.
+    # New results go first so that on equal timestamps the stable sort
+    # keeps freshly fetched data ahead of existing baseline entries.
     results_by_version = {}  # {(ocp_version, gpu_version): [results]}
 
-    # Process existing results (apply filtering to clean up legacy data)
+    for item in new_tests:
+        result = TestResult(**item)
+        if result.has_exact_versions() and result.test_status != STATUS_ABORTED:
+            version_key = get_version_key(result)
+            results_by_version.setdefault(version_key, []).append(result)
+
     for item in existing_tests:
         result = TestResult(**item)
         version_key = get_version_key(result)
         results_by_version.setdefault(version_key, []).append(result)
-
-    # Process new results (should already be filtered, but apply for safety)
-    for item in new_tests:
-        result = TestResult(**item)
-        # Filter: only include results with exact semantic versions and not ABORTED
-        if result.has_exact_versions() and result.test_status != STATUS_ABORTED:
-            version_key = get_version_key(result)
-            results_by_version.setdefault(version_key, []).append(result)
 
     # Keep exactly one result per version key
     final_results = []


### PR DESCRIPTION
When `merge_release_tests` processes results with equal timestamps (same build re-fetched after a code update), Python's stable sort preserves insertion order.

Previously, existing baseline entries were processed first, so stale data without new fields (e.g. `driver_branch`) would win over freshly fetched data. Swapping the loop order ensures new results go first and survive the sort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GPU Operator dashboard release-test result merging.
  - New test results are now prioritized when grouping results by version.
  - Existing baseline results are retained more consistently, including entries that previously could be excluded by filtering.
  - Per-version best-result selection continues to determine which result is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->