### PR TITLE
Fix github API rate limiting issue

### DIFF
--- a/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
+++ b/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import json
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Set
@@ -476,8 +477,11 @@ def process_closed_prs(results_by_ocp: Dict[str, Dict[str, List[Dict[str, Any]]]
               "per_page": "100", "page": "1"}
     headers = {
         "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28"
+        "X-GitHub-Api-Version": "2022-11-28",
     }
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     response_data = http_get_json(url, params=params, headers=headers)
     for pr in response_data:
         pr_number = str(pr["number"])

--- a/.github/workflows/generate_matrix_page.yaml
+++ b/.github/workflows/generate_matrix_page.yaml
@@ -75,6 +75,8 @@ jobs:
           pip install -r .github/scripts/nno_dashboard/requirements.txt
 
       - name: Fetch CI Data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Processing PR: ${{ steps.determine_pr.outputs.PR_NUMBER }}"
           PYTHONPATH=.github/scripts python -m gpu_operator_dashboard.fetch_ci_data \


### PR DESCRIPTION
Yesterday we hit several issues with GitHub API rate limiting (like [this one](https://github.com/rh-ecosystem-edge/nvidia-ci/actions/runs/34118908504)). 

The GitHub API allows 60 requests/hour unauthenticated vs 5000 authenticated.

This is the same approach that microshift uses within this repo. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI data retrieval by authenticating GitHub API requests when a token is available.
  * Enabled the CI data workflow to securely provide its GitHub token during data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->