### PR TITLE
Precompiled: driver branch selection

### DIFF
--- a/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
+++ b/.github/scripts/gpu_operator_dashboard/fetch_ci_data.py
@@ -382,7 +382,8 @@ def process_single_build(
     driver_branch = ""
     driver_branch_file = build_file_set.get('driver_branch')
     if driver_branch_file:
-        driver_branch = fetch_gcs_file_content(driver_branch_file['name']).strip()
+        raw = fetch_gcs_file_content(driver_branch_file['name']).strip()
+        driver_branch = ", ".join(line for line in raw.splitlines() if line.strip())
         logger.info(f"Found driver branch for build {build_id}: {driver_branch}")
 
     if ocp_version_file and gpu_version_file:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ NVIDIA GPU Operator-specific parameters for the script are controlled by the fol
 - `NVIDIAGPU_GPU_CLUSTER_POLICY_PATCH`: a JSON patch to apply to a default cluster policy from ALM examples, written according to
    [RFC 6902](http://tools.ietf.org/html/rfc6902) (also see [kubectl patch](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/)) - _optional_
 - `NVIDIAGPU_USE_PRECOMPILED_DRIVER`: boolean flag to enable precompiled/signed driver testing. When set to `true`, the test discovers the latest precompiled driver version from `registry.redhat.io/nvidia/gpu-driver-rhel9` and patches the ClusterPolicy to use it - Default value is `false` - _optional_
+- `NVIDIAGPU_PRECOMPILED_DRIVER_BRANCH`: controls which precompiled driver branch(es) to test (only applies when `NVIDIAGPU_USE_PRECOMPILED_DRIVER=true`). When empty (default), tests the first discovered branch. Set to `all` to test all discovered branches (deduplicated by major version). Set to a comma-separated list (e.g. `580.178.04,595.91.07`) to test specific branches. Each branch runs a full GPU burn validation - _optional_
 - `NFD_FALLBACK_CATALOGSOURCE_INDEX_IMAGE`:  custom redhat-operators catalogsource index image for NFD package - _required when deploying fallback custom NFD catalogsource_
 
 NVIDIA Network Operator-specific (NNO) parameters for the script are controlled by the following environment variables:

--- a/internal/gpuburn/gpuburn.go
+++ b/internal/gpuburn/gpuburn.go
@@ -26,7 +26,7 @@ var (
   			echo "ERROR No GPUs found"
 			exit 1
 		fi
-		./gpu_burn 300
+		./gpu_burn 60
 
 		if [ ! $? -eq 0 ]; then
 		  exit 1

--- a/internal/nvidiagpuconfig/config.go
+++ b/internal/nvidiagpuconfig/config.go
@@ -17,6 +17,7 @@ type NvidiaGPUConfig struct {
 	GPUFallbackCatalogsourceIndexImage string `envconfig:"NVIDIAGPU_GPU_FALLBACK_CATALOGSOURCE_INDEX_IMAGE"`
 	ClusterPolicyPatch                 string `envconfig:"NVIDIAGPU_GPU_CLUSTER_POLICY_PATCH"`
 	UsePrecompiledDriver               bool   `envconfig:"NVIDIAGPU_USE_PRECOMPILED_DRIVER" default:"false"`
+	PrecompiledDriverBranch            string `envconfig:"NVIDIAGPU_PRECOMPILED_DRIVER_BRANCH"`
 }
 
 // NewNvidiaGPUConfig returns an instance of NvidiaGPUConfig.

--- a/pkg/nvidiagpu/clusterpolicy.go
+++ b/pkg/nvidiagpu/clusterpolicy.go
@@ -99,6 +99,16 @@ func newBuilder(apiClient *clients.Settings, clusterPolicy *nvidiagpuv1.ClusterP
 	return &builder
 }
 
+// NewBuilderFromDefinition creates a Builder from an existing ClusterPolicy definition.
+func NewBuilderFromDefinition(apiClient *clients.Settings, cp *nvidiagpuv1.ClusterPolicy) *Builder {
+	glog.V(100).Infof("Initializing new Builder structure from ClusterPolicy definition: %s", cp.Name)
+
+	return &Builder{
+		apiClient:  apiClient,
+		Definition: cp,
+	}
+}
+
 // Get returns clusterPolicy object if found.
 func (builder *Builder) Get() (*nvidiagpuv1.ClusterPolicy, error) {
 	if valid, err := builder.validate(); !valid {

--- a/pkg/nvidiagpu/precompiled.go
+++ b/pkg/nvidiagpu/precompiled.go
@@ -109,8 +109,9 @@ func DiscoverPrecompiledDriverVersion(apiClient *clients.Settings, kernelVersion
 
 // deduplicateByMajorVersion groups versions by their major prefix (the part
 // before the first dot) and keeps the longest (most specific) version for each
-// group. For example, given ["580.178.04", "580", "595", "595.91.07"], it
-// returns ["580.178.04", "595.91.07"].
+// group. Results are sorted lexicographically ascending. For example, given
+// ["580.178.04", "580", "595", "595.91.07"], it returns ["580.178.04",
+// "595.91.07"].
 func deduplicateByMajorVersion(versions []string) []string {
 	best := make(map[string]string)
 

--- a/pkg/nvidiagpu/precompiled.go
+++ b/pkg/nvidiagpu/precompiled.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -38,10 +39,11 @@ type dockerAuthEntry struct {
 }
 
 // DiscoverPrecompiledDriverVersion queries registry.redhat.io for precompiled
-// driver images matching the given kernel version. It returns the driver branch
-// version (e.g., "580") and serves as validation that precompiled images are
-// available for the given kernel.
-func DiscoverPrecompiledDriverVersion(apiClient *clients.Settings, kernelVersion string) (string, error) {
+// driver images matching the given kernel version. It returns all unique driver
+// branch versions deduplicated by major version prefix (e.g., "580.178.04" and
+// "580" are treated as the same branch, keeping the long form). The returned
+// list is sorted lexicographically.
+func DiscoverPrecompiledDriverVersion(apiClient *clients.Settings, kernelVersion string) ([]string, error) {
 	glog.V(100).Infof("Discovering precompiled driver version for kernel %s", kernelVersion)
 
 	secret := &corev1.Secret{}
@@ -50,22 +52,22 @@ func DiscoverPrecompiledDriverVersion(apiClient *clients.Settings, kernelVersion
 		Name:      "pull-secret",
 	}, secret)
 	if err != nil {
-		return "", fmt.Errorf("failed to read cluster pull-secret: %w", err)
+		return nil, fmt.Errorf("failed to read cluster pull-secret: %w", err)
 	}
 
 	var config dockerConfigJSON
 	if err := json.Unmarshal(secret.Data[".dockerconfigjson"], &config); err != nil {
-		return "", fmt.Errorf("failed to parse pull-secret: %w", err)
+		return nil, fmt.Errorf("failed to parse pull-secret: %w", err)
 	}
 
 	auth, ok := config.Auths[precompiledRegistry]
 	if !ok {
-		return "", fmt.Errorf("no credentials for %s found in cluster pull-secret", precompiledRegistry)
+		return nil, fmt.Errorf("no credentials for %s found in cluster pull-secret", precompiledRegistry)
 	}
 
 	tags, err := listRegistryTags(auth.Auth)
 	if err != nil {
-		return "", fmt.Errorf("failed to list tags from %s/%s: %w", precompiledRegistry, precompiledRepository, err)
+		return nil, fmt.Errorf("failed to list tags from %s/%s: %w", precompiledRegistry, precompiledRepository, err)
 	}
 
 	glog.V(100).Infof("Found %d total tags in %s/%s", len(tags), precompiledRegistry, precompiledRepository)
@@ -92,21 +94,46 @@ func DiscoverPrecompiledDriverVersion(apiClient *clients.Settings, kernelVersion
 	}
 
 	if len(driverVersions) == 0 {
-		return "", fmt.Errorf("no precompiled driver images found for kernel %s in %s/%s",
+		return nil, fmt.Errorf("no precompiled driver images found for kernel %s in %s/%s",
 			kernelVersion, precompiledRegistry, precompiledRepository)
 	}
 
 	glog.V(100).Infof("Found precompiled driver versions for kernel %s: %v", kernelVersion, driverVersions)
 
-	for _, v := range driverVersions {
-		if !strings.Contains(v, ".") {
-			glog.V(100).Infof("Selected precompiled driver branch version: %s", v)
-			return v, nil
+	deduplicated := deduplicateByMajorVersion(driverVersions)
+
+	glog.V(100).Infof("Deduplicated precompiled driver versions: %v", deduplicated)
+
+	return deduplicated, nil
+}
+
+// deduplicateByMajorVersion groups versions by their major prefix (the part
+// before the first dot) and keeps the longest (most specific) version for each
+// group. For example, given ["580.178.04", "580", "595", "595.91.07"], it
+// returns ["580.178.04", "595.91.07"].
+func deduplicateByMajorVersion(versions []string) []string {
+	best := make(map[string]string)
+
+	for _, v := range versions {
+		major := v
+		if idx := strings.Index(v, "."); idx > 0 {
+			major = v[:idx]
+		}
+
+		existing, ok := best[major]
+		if !ok || len(v) > len(existing) {
+			best[major] = v
 		}
 	}
 
-	glog.V(100).Infof("No short-form driver version found, using: %s", driverVersions[0])
-	return driverVersions[0], nil
+	result := make([]string, 0, len(best))
+	for _, v := range best {
+		result = append(result, v)
+	}
+
+	sort.Strings(result)
+
+	return result
 }
 
 func listRegistryTags(authBase64 string) ([]string, error) {

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -690,8 +690,12 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 					precompiledBranches = discoveredVersions
 				default:
 					for _, b := range strings.Split(branchSetting, ",") {
-						precompiledBranches = append(precompiledBranches, strings.TrimSpace(b))
+						if trimmed := strings.TrimSpace(b); trimmed != "" {
+							precompiledBranches = append(precompiledBranches, trimmed)
+						}
 					}
+					Expect(precompiledBranches).ToNot(BeEmpty(),
+						"NVIDIAGPU_PRECOMPILED_DRIVER_BRANCH=%q produced no valid branches", branchSetting)
 				}
 
 				glog.V(gpuparams.GpuLogLevel).Infof("Precompiled driver branches to test: %v", precompiledBranches)

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -966,7 +966,14 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				err = wait.ClusterPolicyReady(inittools.APIClient, nvidiagpu.ClusterPolicyName,
 					nvidiagpu.ClusterPolicyReadyCheckInterval, nvidiagpu.ClusterPolicyReadyTimeout)
 				Expect(err).ToNot(HaveOccurred(), "ClusterPolicy not ready after switching to branch %s", nextBranch)
-				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy ready with driver branch %s", nextBranch)
+
+				By(fmt.Sprintf("Verify ClusterPolicy driver version is %s", nextBranch))
+				verifyCP, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterPolicy for version verification")
+				Expect(verifyCP.Definition.Spec.Driver.Version).To(Equal(nextBranch),
+					"ClusterPolicy driver version mismatch: expected %s, got %s",
+					nextBranch, verifyCP.Definition.Spec.Driver.Version)
+				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy ready with verified driver branch %s", nextBranch)
 
 				By(fmt.Sprintf("Delete previous gpu-burn pod before testing branch %s", nextBranch))
 				oldPod, _ := pod.Pull(inittools.APIClient, burn.PodName, burn.Namespace)

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -663,6 +663,8 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			clusterPolicyPatch := nvidiaGPUConfig.ClusterPolicyPatch
 
+			var precompiledBranches []string
+
 			if nvidiaGPUConfig.UsePrecompiledDriver {
 				glog.V(gpuparams.GpuLogLevel).Infof("UsePrecompiledDriver is enabled, discovering driver version from registry")
 
@@ -676,12 +678,28 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 				kernelVersion := workerNodes[0].Object.Status.NodeInfo.KernelVersion
 				glog.V(gpuparams.GpuLogLevel).Infof("Worker node kernel version: %s", kernelVersion)
 
-				driverVersion, err := nvidiagpu.DiscoverPrecompiledDriverVersion(inittools.APIClient, kernelVersion)
+				discoveredVersions, err := nvidiagpu.DiscoverPrecompiledDriverVersion(inittools.APIClient, kernelVersion)
 				Expect(err).ToNot(HaveOccurred(), "Failed to discover precompiled driver version: %v", err)
-				glog.V(gpuparams.GpuLogLevel).Infof("Discovered precompiled driver version: %s", driverVersion)
+				glog.V(gpuparams.GpuLogLevel).Infof("Discovered precompiled driver versions: %v", discoveredVersions)
+
+				branchSetting := nvidiaGPUConfig.PrecompiledDriverBranch
+				switch {
+				case branchSetting == "":
+					precompiledBranches = discoveredVersions[:1]
+				case strings.EqualFold(branchSetting, "all"):
+					precompiledBranches = discoveredVersions
+				default:
+					for _, b := range strings.Split(branchSetting, ",") {
+						precompiledBranches = append(precompiledBranches, strings.TrimSpace(b))
+					}
+				}
+
+				glog.V(gpuparams.GpuLogLevel).Infof("Precompiled driver branches to test: %v", precompiledBranches)
+
+				driverVersion := precompiledBranches[0]
 
 				if err := inittools.GeneralConfig.WriteReport(
-					DriverBranchVersionsFile, []byte(driverVersion+"\n")); err != nil {
+					DriverBranchVersionsFile, []byte(strings.Join(precompiledBranches, "\n")+"\n")); err != nil {
 					glog.Error("Error writing driver branch versions file: ", err)
 				}
 
@@ -925,6 +943,69 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 
 			Expect(match1 && match2).ToNot(BeFalse(), "gpu-burn pod execution was FAILED")
 			glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod execution was successful")
+
+			for i := 1; i < len(precompiledBranches); i++ {
+				nextBranch := precompiledBranches[i]
+				By(fmt.Sprintf("Testing additional precompiled driver branch: %s (%d/%d)",
+					nextBranch, i+1, len(precompiledBranches)))
+
+				By(fmt.Sprintf("Update ClusterPolicy driver version to %s", nextBranch))
+				pulledCP, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterPolicy")
+
+				pulledCP.Definition.Spec.Driver.Version = nextBranch
+				_, err = pulledCP.Update(false)
+				Expect(err).ToNot(HaveOccurred(), "Failed to update ClusterPolicy driver version to %s", nextBranch)
+				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy driver version updated to %s", nextBranch)
+
+				By(fmt.Sprintf("Wait for ClusterPolicy to be ready with driver branch %s", nextBranch))
+				err = wait.ClusterPolicyReady(inittools.APIClient, nvidiagpu.ClusterPolicyName,
+					nvidiagpu.ClusterPolicyReadyCheckInterval, nvidiagpu.ClusterPolicyReadyTimeout)
+				Expect(err).ToNot(HaveOccurred(), "ClusterPolicy not ready after switching to branch %s", nextBranch)
+				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy ready with driver branch %s", nextBranch)
+
+				By(fmt.Sprintf("Delete previous gpu-burn pod before testing branch %s", nextBranch))
+				oldPod, _ := pod.Pull(inittools.APIClient, burn.PodName, burn.Namespace)
+				if oldPod != nil {
+					_, err = oldPod.Delete()
+					Expect(err).ToNot(HaveOccurred(), "Failed to delete old gpu-burn pod")
+					err = oldPod.WaitUntilDeleted(2 * time.Minute)
+					Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not deleted in time")
+				}
+
+				By(fmt.Sprintf("Deploy gpu-burn pod for branch %s", nextBranch))
+				newGpuBurnPod, err := gpuburn.CreateGPUBurnPod(inittools.APIClient, burn.PodName, burn.Namespace,
+					BurnImageName[clusterArchitecture], nvidiagpu.BurnPodCreationTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Error creating gpu burn pod for branch %s", nextBranch)
+
+				_, err = inittools.APIClient.Pods(newGpuBurnPod.Namespace).Create(context.TODO(), newGpuBurnPod,
+					metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Error creating gpu-burn pod for branch %s", nextBranch)
+
+				By(fmt.Sprintf("Wait for gpu-burn pod to complete for branch %s", nextBranch))
+				newPodPulled, err := pod.Pull(inittools.APIClient, burn.PodName, burn.Namespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed to pull gpu-burn pod")
+
+				err = newPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
+				Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not scheduled for branch %s", nextBranch)
+
+				err = newPodPulled.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
+				Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not running for branch %s", nextBranch)
+
+				err = newPodPulled.WaitUntilInStatus(corev1.PodSucceeded, nvidiagpu.BurnPodSuccessTimeout)
+				Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not succeeded for branch %s", nextBranch)
+
+				By(fmt.Sprintf("Verify gpu-burn logs for branch %s", nextBranch))
+				branchLogs, err := newPodPulled.GetLog(nvidiagpu.BurnLogCollectionPeriod, "gpu-burn-ctr")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get gpu-burn logs for branch %s", nextBranch)
+				glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod logs for branch %s:\n%s", nextBranch, branchLogs)
+
+				branchOK1 := strings.Contains(branchLogs, "GPU 0: OK")
+				branchOK2 := strings.Contains(branchLogs, "100.0%  proc'd:")
+				Expect(branchOK1 && branchOK2).ToNot(BeFalse(),
+					"gpu-burn execution FAILED for driver branch %s", nextBranch)
+				glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn successful for driver branch %s", nextBranch)
+			}
 
 		})
 

--- a/tests/nvidiagpu/deploygpu_test.go
+++ b/tests/nvidiagpu/deploygpu_test.go
@@ -948,75 +948,24 @@ var _ = Describe("GPU", Ordered, Label(tsparams.LabelSuite), func() {
 			Expect(match1 && match2).ToNot(BeFalse(), "gpu-burn pod execution was FAILED")
 			glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod execution was successful")
 
+			var failedBranches []string
+
 			for i := 1; i < len(precompiledBranches); i++ {
 				nextBranch := precompiledBranches[i]
 				By(fmt.Sprintf("Testing additional precompiled driver branch: %s (%d/%d)",
 					nextBranch, i+1, len(precompiledBranches)))
 
-				By(fmt.Sprintf("Update ClusterPolicy driver version to %s", nextBranch))
-				pulledCP, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
-				Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterPolicy")
-
-				pulledCP.Definition.Spec.Driver.Version = nextBranch
-				_, err = pulledCP.Update(false)
-				Expect(err).ToNot(HaveOccurred(), "Failed to update ClusterPolicy driver version to %s", nextBranch)
-				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy driver version updated to %s", nextBranch)
-
-				By(fmt.Sprintf("Wait for ClusterPolicy to be ready with driver branch %s", nextBranch))
-				err = wait.ClusterPolicyReady(inittools.APIClient, nvidiagpu.ClusterPolicyName,
-					nvidiagpu.ClusterPolicyReadyCheckInterval, nvidiagpu.ClusterPolicyReadyTimeout)
-				Expect(err).ToNot(HaveOccurred(), "ClusterPolicy not ready after switching to branch %s", nextBranch)
-
-				By(fmt.Sprintf("Verify ClusterPolicy driver version is %s", nextBranch))
-				verifyCP, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
-				Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterPolicy for version verification")
-				Expect(verifyCP.Definition.Spec.Driver.Version).To(Equal(nextBranch),
-					"ClusterPolicy driver version mismatch: expected %s, got %s",
-					nextBranch, verifyCP.Definition.Spec.Driver.Version)
-				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy ready with verified driver branch %s", nextBranch)
-
-				By(fmt.Sprintf("Delete previous gpu-burn pod before testing branch %s", nextBranch))
-				oldPod, _ := pod.Pull(inittools.APIClient, burn.PodName, burn.Namespace)
-				if oldPod != nil {
-					_, err = oldPod.Delete()
-					Expect(err).ToNot(HaveOccurred(), "Failed to delete old gpu-burn pod")
-					err = oldPod.WaitUntilDeleted(2 * time.Minute)
-					Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not deleted in time")
+				branchErr := testPrecompiledBranch(nextBranch, i, burn, clusterArchitecture)
+				if branchErr != nil {
+					glog.V(gpuparams.GpuLogLevel).Infof("Branch %s FAILED: %v", nextBranch, branchErr)
+					failedBranches = append(failedBranches, fmt.Sprintf("%s: %v", nextBranch, branchErr))
+				} else {
+					glog.V(gpuparams.GpuLogLevel).Infof("Branch %s PASSED", nextBranch)
 				}
-
-				By(fmt.Sprintf("Deploy gpu-burn pod for branch %s", nextBranch))
-				newGpuBurnPod, err := gpuburn.CreateGPUBurnPod(inittools.APIClient, burn.PodName, burn.Namespace,
-					BurnImageName[clusterArchitecture], nvidiagpu.BurnPodCreationTimeout)
-				Expect(err).ToNot(HaveOccurred(), "Error creating gpu burn pod for branch %s", nextBranch)
-
-				_, err = inittools.APIClient.Pods(newGpuBurnPod.Namespace).Create(context.TODO(), newGpuBurnPod,
-					metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Error creating gpu-burn pod for branch %s", nextBranch)
-
-				By(fmt.Sprintf("Wait for gpu-burn pod to complete for branch %s", nextBranch))
-				newPodPulled, err := pod.Pull(inittools.APIClient, burn.PodName, burn.Namespace)
-				Expect(err).ToNot(HaveOccurred(), "Failed to pull gpu-burn pod")
-
-				err = newPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
-				Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not scheduled for branch %s", nextBranch)
-
-				err = newPodPulled.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
-				Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not running for branch %s", nextBranch)
-
-				err = newPodPulled.WaitUntilInStatus(corev1.PodSucceeded, nvidiagpu.BurnPodSuccessTimeout)
-				Expect(err).ToNot(HaveOccurred(), "gpu-burn pod not succeeded for branch %s", nextBranch)
-
-				By(fmt.Sprintf("Verify gpu-burn logs for branch %s", nextBranch))
-				branchLogs, err := newPodPulled.GetLog(nvidiagpu.BurnLogCollectionPeriod, "gpu-burn-ctr")
-				Expect(err).ToNot(HaveOccurred(), "Failed to get gpu-burn logs for branch %s", nextBranch)
-				glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod logs for branch %s:\n%s", nextBranch, branchLogs)
-
-				branchOK1 := strings.Contains(branchLogs, "GPU 0: OK")
-				branchOK2 := strings.Contains(branchLogs, "100.0%  proc'd:")
-				Expect(branchOK1 && branchOK2).ToNot(BeFalse(),
-					"gpu-burn execution FAILED for driver branch %s", nextBranch)
-				glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn successful for driver branch %s", nextBranch)
 			}
+
+			Expect(failedBranches).To(BeEmpty(),
+				"The following driver branches failed:\n%s", strings.Join(failedBranches, "\n"))
 
 		})
 
@@ -1387,6 +1336,228 @@ func cleanupGPUBurnConfigmap() {
 		Expect(err).ToNot(HaveOccurred(), "Error deleting gpu-burn configmap: %v", err)
 		glog.V(gpuparams.GpuLogLevel).Infof("Successfully deleted gpu-burn configmap '%s'", burn.ConfigMapName)
 	}
+}
+
+//nolint:funlen,cyclop
+func testPrecompiledBranch(nextBranch string, branchIndex int,
+	burn *nvidiagpu.GPUBurnConfig, clusterArchitecture string) error {
+
+	By("Delete ClusterPolicy to force full driver cleanup including host firmware state")
+
+	pulledCP, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
+	if err != nil {
+		return fmt.Errorf("failed to pull ClusterPolicy: %w", err)
+	}
+
+	cpDefinition := pulledCP.Definition.DeepCopy()
+
+	_, err = pulledCP.Delete()
+	if err != nil {
+		return fmt.Errorf("failed to delete ClusterPolicy: %w", err)
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy deleted, waiting for nvidia pods to terminate")
+
+	By("Wait for all nvidia driver pods to terminate")
+
+	terminated := false
+
+	for elapsed := 0; elapsed < 300; elapsed += 10 {
+		driverPods, listErr := pod.ListByNamePattern(
+			inittools.APIClient, "nvidia-driver-daemonset", nvidiagpu.NvidiaGPUNamespace)
+		if listErr == nil && len(driverPods) == 0 {
+			terminated = true
+
+			break
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	if !terminated {
+		return fmt.Errorf("driver pods did not terminate after ClusterPolicy deletion")
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("All driver pods terminated")
+
+	By("Clean host driver state on GPU worker nodes")
+
+	gpuNodeSelector := fmt.Sprintf("%s=,%s=true",
+		inittools.GeneralConfig.WorkerLabel, nvidiagpu.NvidiaGPULabel)
+
+	gpuWorkerNodes, err := nodes.List(inittools.APIClient,
+		metav1.ListOptions{LabelSelector: gpuNodeSelector})
+	if err != nil {
+		return fmt.Errorf("failed to list GPU worker nodes: %w", err)
+	}
+
+	for j, gpuNode := range gpuWorkerNodes {
+		cleanupPodName := fmt.Sprintf("driver-cleanup-%d-%d", branchIndex, j)
+		cleanupPodSpec := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cleanupPodName,
+				Namespace: nvidiagpu.NvidiaGPUNamespace,
+			},
+			Spec: corev1.PodSpec{
+				HostPID:       true,
+				NodeName:      gpuNode.Object.Name,
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{
+					{
+						Name:  "cleanup",
+						Image: "registry.access.redhat.com/ubi9/ubi:latest",
+						Command: []string{"nsenter", "-t", "1", "-m", "-u", "-i", "-n", "--", "sh", "-c",
+							"findmnt -r -o TARGET | grep nvidia/driver | sort -r | " +
+								"while read mnt; do umount \"$mnt\" 2>/dev/null || umount -l \"$mnt\" 2>/dev/null; done; " +
+								"echo '' > /sys/module/firmware_class/parameters/path; " +
+								"rm -rf /run/nvidia/driver; " +
+								"echo cleanup-done"},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged: func() *bool { b := true; return &b }(),
+						},
+					},
+				},
+			},
+		}
+
+		glog.V(gpuparams.GpuLogLevel).Infof(
+			"Creating cleanup pod %s on node %s", cleanupPodName, gpuNode.Object.Name)
+
+		_, err = inittools.APIClient.Pods(nvidiagpu.NvidiaGPUNamespace).Create(
+			context.TODO(), cleanupPodSpec, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create cleanup pod on node %s: %w", gpuNode.Object.Name, err)
+		}
+
+		cleanupPodPulled, err := pod.Pull(
+			inittools.APIClient, cleanupPodName, nvidiagpu.NvidiaGPUNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to pull cleanup pod: %w", err)
+		}
+
+		err = cleanupPodPulled.WaitUntilInStatus(corev1.PodSucceeded, 2*time.Minute)
+		if err != nil {
+			return fmt.Errorf("cleanup pod did not succeed on node %s: %w", gpuNode.Object.Name, err)
+		}
+
+		cleanupLogs, _ := cleanupPodPulled.GetLog(30*time.Second, "cleanup")
+		glog.V(gpuparams.GpuLogLevel).Infof(
+			"Cleanup logs for node %s: %s", gpuNode.Object.Name, cleanupLogs)
+
+		_, _ = cleanupPodPulled.Delete()
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Host driver state cleaned on all GPU nodes")
+
+	By(fmt.Sprintf("Recreate ClusterPolicy with driver branch %s", nextBranch))
+
+	cpDefinition.Spec.Driver.Version = nextBranch
+	cpDefinition.ResourceVersion = ""
+	cpDefinition.UID = ""
+	cpDefinition.Generation = 0
+	cpDefinition.CreationTimestamp = metav1.Time{}
+
+	newCP := nvidiagpu.NewBuilderFromDefinition(inittools.APIClient, cpDefinition)
+
+	_, err = newCP.Create()
+	if err != nil {
+		return fmt.Errorf("failed to create ClusterPolicy with driver branch %s: %w", nextBranch, err)
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy created with driver branch %s", nextBranch)
+
+	By(fmt.Sprintf("Wait for ClusterPolicy to be ready with driver branch %s", nextBranch))
+
+	err = wait.ClusterPolicyReady(inittools.APIClient, nvidiagpu.ClusterPolicyName,
+		nvidiagpu.ClusterPolicyReadyCheckInterval, nvidiagpu.ClusterPolicyReadyTimeout)
+	if err != nil {
+		return fmt.Errorf("ClusterPolicy not ready after switching to branch %s: %w", nextBranch, err)
+	}
+
+	By(fmt.Sprintf("Verify ClusterPolicy driver version is %s", nextBranch))
+
+	verifyCP, err := nvidiagpu.Pull(inittools.APIClient, nvidiagpu.ClusterPolicyName)
+	if err != nil {
+		return fmt.Errorf("failed to pull ClusterPolicy for version verification: %w", err)
+	}
+
+	if verifyCP.Definition.Spec.Driver.Version != nextBranch {
+		return fmt.Errorf("ClusterPolicy driver version mismatch: expected %s, got %s",
+			nextBranch, verifyCP.Definition.Spec.Driver.Version)
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy ready with verified driver branch %s", nextBranch)
+
+	By(fmt.Sprintf("Delete previous gpu-burn pod before testing branch %s", nextBranch))
+
+	oldPod, _ := pod.Pull(inittools.APIClient, burn.PodName, burn.Namespace)
+	if oldPod != nil {
+		_, err = oldPod.Delete()
+		if err != nil {
+			return fmt.Errorf("failed to delete old gpu-burn pod: %w", err)
+		}
+
+		err = oldPod.WaitUntilDeleted(2 * time.Minute)
+		if err != nil {
+			return fmt.Errorf("gpu-burn pod not deleted in time: %w", err)
+		}
+	}
+
+	By(fmt.Sprintf("Deploy gpu-burn pod for branch %s", nextBranch))
+
+	newGpuBurnPod, err := gpuburn.CreateGPUBurnPod(inittools.APIClient, burn.PodName, burn.Namespace,
+		BurnImageName[clusterArchitecture], nvidiagpu.BurnPodCreationTimeout)
+	if err != nil {
+		return fmt.Errorf("error creating gpu burn pod for branch %s: %w", nextBranch, err)
+	}
+
+	_, err = inittools.APIClient.Pods(newGpuBurnPod.Namespace).Create(context.TODO(), newGpuBurnPod,
+		metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating gpu-burn pod for branch %s: %w", nextBranch, err)
+	}
+
+	By(fmt.Sprintf("Wait for gpu-burn pod to complete for branch %s", nextBranch))
+
+	newPodPulled, err := pod.Pull(inittools.APIClient, burn.PodName, burn.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to pull gpu-burn pod: %w", err)
+	}
+
+	err = newPodPulled.WaitUntilScheduled(nvidiagpu.BurnPodScheduledTimeout)
+	if err != nil {
+		return fmt.Errorf("gpu-burn pod not scheduled for branch %s: %w", nextBranch, err)
+	}
+
+	err = newPodPulled.WaitUntilRunningOrSucceeded(nvidiagpu.BurnPodRunningTimeout)
+	if err != nil {
+		return fmt.Errorf("gpu-burn pod not running for branch %s: %w", nextBranch, err)
+	}
+
+	err = newPodPulled.WaitUntilInStatus(corev1.PodSucceeded, nvidiagpu.BurnPodSuccessTimeout)
+	if err != nil {
+		return fmt.Errorf("gpu-burn pod not succeeded for branch %s: %w", nextBranch, err)
+	}
+
+	By(fmt.Sprintf("Verify gpu-burn logs for branch %s", nextBranch))
+
+	branchLogs, err := newPodPulled.GetLog(nvidiagpu.BurnLogCollectionPeriod, "gpu-burn-ctr")
+	if err != nil {
+		return fmt.Errorf("failed to get gpu-burn logs for branch %s: %w", nextBranch, err)
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn pod logs for branch %s:\n%s", nextBranch, branchLogs)
+
+	branchOK1 := strings.Contains(branchLogs, "GPU 0: OK")
+	branchOK2 := strings.Contains(branchLogs, "100.0%  proc'd:")
+
+	if !branchOK1 || !branchOK2 {
+		return fmt.Errorf("gpu-burn execution FAILED for driver branch %s", nextBranch)
+	}
+
+	glog.V(gpuparams.GpuLogLevel).Infof("Gpu-burn successful for driver branch %s", nextBranch)
+
+	return nil
 }
 
 // cleanupGPUBurnNamespace deletes the GPU Burn namespace


### PR DESCRIPTION
Adds a new `NVIDIAGPU_PRECOMPILED_DRIVER_BRANCH` variable, that controls which precompiled driver branch(es) to test (only applies when `NVIDIAGPU_USE_PRECOMPILED_DRIVER=true`):
 - When empty (default), tests the first discovered branch. 
 -  Set to `all` to test all discovered branches (deduplicated by major version)
 - Set to a comma-separated list (e.g. `580.178.04,595.91.07`) to test specific branches. Each branch runs a full GPU burn validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU Operator test runs can now validate multiple precompiled driver branches.
  * Added optional configuration to test the first discovered branch, all available branches, or a specified comma-separated selection.
  * Each selected branch undergoes GPU burn validation, with results included in the driver report.
* **Improvements**
  * Precompiled driver branch discovery now returns sorted, deduplicated results.
  * Driver branch data is presented in a consistent comma-separated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->