### PR TITLE
Open issue when new GPU Operator driver version is available

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -45,6 +45,24 @@ jobs:
           SETTINGS_FILE_PATH: ".github/scripts/gpu_operator_versions/settings.json"
           TEST_TO_TRIGGER_FILE_PATH: ".github/scripts/generated-files/tests_to_trigger.txt"
           CHECK_CATALOG_AVAILABILITY: "true"
+      - name: Detect new GPU operator channels
+        id: new_gpu_channels
+        env:
+          VERSIONS_FILE: .github/scripts/gpu_operator_versions/versions.json
+        run: |
+          old_channels=$(git show HEAD:"${VERSIONS_FILE}" | jq -r '."gpu-operator" | keys[]')
+          new_channels=$(jq -r '."gpu-operator" | keys[]' "${VERSIONS_FILE}")
+          new_gpu=$(comm -23 <(echo "${new_channels}") <(echo "${old_channels}"))
+
+          if [ -z "${new_gpu}" ]; then
+            echo "No new GPU operator channels detected."
+            echo "channels=" >> "$GITHUB_OUTPUT"
+          else
+            echo "New GPU operator channels detected:"
+            echo "${new_gpu}"
+            echo "channels=$(echo "${new_gpu}" | paste -sd, -)" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Update Signed Versions
         id: read_signed_tests
         run: |
@@ -100,6 +118,40 @@ jobs:
             exit 0
           fi
           gh pr comment "${PR_NUMBER}" --body "${ALL_TRIGGERS}"
+
+      - name: Create issues for new GPU operator channels
+        if: steps.new_gpu_channels.outputs.channels != ''
+        uses: actions/github-script@v7
+        env:
+          NEW_CHANNELS: ${{ steps.new_gpu_channels.outputs.channels }}
+        with:
+          script: |
+            const channels = process.env.NEW_CHANNELS.split(',');
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'operator-available'
+            });
+
+            for (const channel of channels) {
+              const issueTitle = `New GPU operator channel available: v${channel}`;
+              const existingIssue = issues.find(issue => issue.title === issueTitle);
+
+              if (!existingIssue) {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: issueTitle,
+                  body: `A new GPU operator channel **v${channel}** has been detected.\n\n## Tasks\n\n- [ ] Ensure Prow jobs exist for this channel\n- [ ] Confirm the version appears in \`versions.json\` after the PR is merged\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                  labels: ['operator-available']
+                });
+                console.log(`Created issue for channel v${channel}`);
+              } else {
+                console.log(`Issue already exists for channel v${channel}: #${existingIssue.number}`);
+              }
+            }
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
Closes https://github.com/rh-ecosystem-edge/nvidia-ci/issues/661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically identifies newly available GPU operator channels.
  - Creates a tracking issue for each new channel, including a checklist for follow-up.
  - Prevents duplicate tracking issues when one is already open for the channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->